### PR TITLE
Implement logs for responses

### DIFF
--- a/src/app/components/environment-logs.component.html
+++ b/src/app/components/environment-logs.component.html
@@ -38,8 +38,8 @@
         <div *ngIf="environmentsLogs[activeEnvironmentUUID][(selectedLogIndex$ | async)] as selectedLog"
           class="environment-logs-content pl-2 pr-2">
           <ngb-tabset #t="ngbTabset">
-            <ngb-tab id="tab-request" title="Request">
-              <ng-template ngbTabTitle><i class="material-icons">call_made</i></ng-template>
+            <ngb-tab id="tab-request">
+              <ng-template ngbTabTitle>Request <i class="material-icons">call_made</i></ng-template>
               <ng-template ngbTabContent>
                 <div class="environment-logs-content-title" (click)="generalCollapsed = !generalCollapsed">
                   <i *ngIf="!generalCollapsed" class="material-icons">unfold_less</i>
@@ -105,8 +105,8 @@
                 </div>
               </ng-template>
             </ngb-tab>
-            <ngb-tab id="tab-response" title="Response">
-              <ng-template ngbTabTitle><i class="material-icons">call_received</i></ng-template>
+            <ngb-tab id="tab-response">
+              <ng-template ngbTabTitle>Response <i class="material-icons">call_received</i></ng-template>
               <ng-template ngbTabContent>
                 <div *ngIf="selectedLog.response != null">
                   <!-- General Response -->

--- a/src/app/components/environment-logs.component.html
+++ b/src/app/components/environment-logs.component.html
@@ -37,68 +37,119 @@
       <div class="col h-100 environment-logs-column">
         <div *ngIf="environmentsLogs[activeEnvironmentUUID][(selectedLogIndex$ | async)] as selectedLog"
           class="environment-logs-content pl-2 pr-2">
-          <div class="environment-logs-content-title" (click)="generalCollapsed = !generalCollapsed">
-            <i *ngIf="!generalCollapsed" class="material-icons">unfold_less</i>
-            <i *ngIf="generalCollapsed" class="material-icons">unfold_more</i>
-            General
-          </div>
-          <div [ngbCollapse]="generalCollapsed">
-            <div class="environment-logs-content-item">
-              <strong>Request URL:</strong> {{selectedLog.url}}
-            </div>
-            <div class="environment-logs-content-item">
-              <strong>Method:</strong> {{selectedLog.method}}
-            </div>
-            <div *ngIf="selectedLog.route" class="environment-logs-content-item">
-              <strong>Caught by route:</strong> {{selectedLog.route}}
-            </div>
-          </div>
-
-          <!-- Headers -->
-          <div class="environment-logs-content-title" (click)="headersCollapsed = !headersCollapsed">
-            <i *ngIf="selectedLog.headers.length && !headersCollapsed" class="material-icons">unfold_less</i>
-            <i *ngIf="selectedLog.headers.length && headersCollapsed" class="material-icons">unfold_more</i>
-            Headers ({{selectedLog?.headers?.length}})
-          </div>
-          <div [ngbCollapse]="headersCollapsed">
-            <div class="environment-logs-content-item" *ngFor="let header of selectedLog?.headers">
-              <strong>{{header.name | titlecase}}:</strong> {{header.value}}
-            </div>
-          </div>
-
-          <!-- Route params -->
-          <div class="environment-logs-content-title" (click)="routeParamsCollapsed = !routeParamsCollapsed">
-            <i *ngIf="selectedLog.params.length && !routeParamsCollapsed" class="material-icons">unfold_less</i>
-            <i *ngIf="selectedLog.params.length && routeParamsCollapsed" class="material-icons">unfold_more</i>
-            Route params ({{selectedLog?.params?.length}})
-          </div>
-          <div [ngbCollapse]="routeParamsCollapsed">
-            <div class="environment-logs-content-item" *ngFor="let param of selectedLog?.params">
-              <strong>{{param.name}}:</strong> {{param.value}}
-            </div>
-          </div>
-
-          <!-- Query params -->
-          <div class="environment-logs-content-title" (click)="queryParamsCollapsed = !queryParamsCollapsed">
-            <i *ngIf="selectedLog.queryParams.length && !queryParamsCollapsed" class="material-icons">unfold_less</i>
-            <i *ngIf="selectedLog.queryParams.length && queryParamsCollapsed" class="material-icons">unfold_more</i>
-            Query params ({{selectedLog?.queryParams?.length}})
-          </div>
-          <div [ngbCollapse]="queryParamsCollapsed">
-            <div class="environment-logs-content-item" *ngFor="let queryParam of selectedLog?.queryParams">
-              <strong>{{queryParam.name}}:</strong> {{queryParam.value}}
-            </div>
-          </div>
-
-          <!-- Body -->
-          <div class="environment-logs-content-title" (click)="bodyCollapsed = !bodyCollapsed">
-            <i *ngIf="selectedLog.body && !bodyCollapsed" class="material-icons">unfold_less</i>
-            <i *ngIf="selectedLog.body && bodyCollapsed" class="material-icons">unfold_more</i>
-            Body ({{(!selectedLog.body)?'none': 'raw'}})
-          </div>
-          <div [ngbCollapse]="bodyCollapsed">
-            <div class="environment-logs-content-item pre">{{selectedLog.body}}</div>
-          </div>
+          <ngb-tabset #t="ngbTabset">
+            <ngb-tab id="tab-request" title="Request">
+              <ng-template ngbTabTitle><i class="material-icons">call_made</i></ng-template>
+              <ng-template ngbTabContent>
+                <div class="environment-logs-content-title" (click)="generalCollapsed = !generalCollapsed">
+                  <i *ngIf="!generalCollapsed" class="material-icons">unfold_less</i>
+                  <i *ngIf="generalCollapsed" class="material-icons">unfold_more</i>
+                  General
+                </div>
+                <div [ngbCollapse]="generalCollapsed">
+                  <div class="environment-logs-content-item">
+                    <strong>Request URL:</strong> {{selectedLog.url}}
+                  </div>
+                  <div class="environment-logs-content-item">
+                    <strong>Method:</strong> {{selectedLog.method}}
+                  </div>
+                  <div *ngIf="selectedLog.route" class="environment-logs-content-item">
+                    <strong>Caught by route:</strong> {{selectedLog.route}}
+                  </div>
+                </div>
+      
+                <!-- Headers -->
+                <div class="environment-logs-content-title" (click)="headersCollapsed = !headersCollapsed">
+                  <i *ngIf="selectedLog.headers.length && !headersCollapsed" class="material-icons">unfold_less</i>
+                  <i *ngIf="selectedLog.headers.length && headersCollapsed" class="material-icons">unfold_more</i>
+                  Headers ({{selectedLog?.headers?.length}})
+                </div>
+                <div [ngbCollapse]="headersCollapsed">
+                  <div class="environment-logs-content-item" *ngFor="let header of selectedLog?.headers">
+                    <strong>{{header.name | titlecase}}:</strong> {{header.value}}
+                  </div>
+                </div>
+      
+                <!-- Route params -->
+                <div class="environment-logs-content-title" (click)="routeParamsCollapsed = !routeParamsCollapsed">
+                  <i *ngIf="selectedLog.params.length && !routeParamsCollapsed" class="material-icons">unfold_less</i>
+                  <i *ngIf="selectedLog.params.length && routeParamsCollapsed" class="material-icons">unfold_more</i>
+                  Route params ({{selectedLog?.params?.length}})
+                </div>
+                <div [ngbCollapse]="routeParamsCollapsed">
+                  <div class="environment-logs-content-item" *ngFor="let param of selectedLog?.params">
+                    <strong>{{param.name}}:</strong> {{param.value}}
+                  </div>
+                </div>
+      
+                <!-- Query params -->
+                <div class="environment-logs-content-title" (click)="queryParamsCollapsed = !queryParamsCollapsed">
+                  <i *ngIf="selectedLog.queryParams.length && !queryParamsCollapsed" class="material-icons">unfold_less</i>
+                  <i *ngIf="selectedLog.queryParams.length && queryParamsCollapsed" class="material-icons">unfold_more</i>
+                  Query params ({{selectedLog?.queryParams?.length}})
+                </div>
+                <div [ngbCollapse]="queryParamsCollapsed">
+                  <div class="environment-logs-content-item" *ngFor="let queryParam of selectedLog?.queryParams">
+                    <strong>{{queryParam.name}}:</strong> {{queryParam.value}}
+                  </div>
+                </div>
+      
+                <!-- Body -->
+                <div class="environment-logs-content-title" (click)="bodyCollapsed = !bodyCollapsed">
+                  <i *ngIf="selectedLog.body && !bodyCollapsed" class="material-icons">unfold_less</i>
+                  <i *ngIf="selectedLog.body && bodyCollapsed" class="material-icons">unfold_more</i>
+                  Body ({{(!selectedLog.body)?'none': 'raw'}})
+                </div>
+                <div [ngbCollapse]="bodyCollapsed">
+                  <div class="environment-logs-content-item pre">{{selectedLog.body}}</div>
+                </div>
+              </ng-template>
+            </ngb-tab>
+            <ngb-tab id="tab-response" title="Response">
+              <ng-template ngbTabTitle><i class="material-icons">call_received</i></ng-template>
+              <ng-template ngbTabContent>
+                <div *ngIf="selectedLog.response != null">
+                  <!-- General Response -->
+                  <div *ngIf="selectedLog.response != null" class="environment-logs-content-title" (click)="responseGeneralCollapsed = !responseGeneralCollapsed">
+                    <i *ngIf="!responseGeneralCollapsed" class="material-icons">unfold_less</i>
+                    <i *ngIf="responseGeneralCollapsed" class="material-icons">unfold_more</i>
+                    General
+                  </div>
+                  <div [ngbCollapse]="responseGeneralCollapsed">
+                    <div class="environment-logs-content-item">
+                      <strong>Status:</strong> {{selectedLog.response?.status}}
+                    </div>
+                  </div>
+        
+                  <!-- Response Headers -->
+                  <div *ngIf="selectedLog.response != null" class="environment-logs-content-title" (click)="responseHeadersCollapsed = !responseHeadersCollapsed">
+                    <i *ngIf="selectedLog.response?.headers.length && !responseHeadersCollapsed" class="material-icons">unfold_less</i>
+                    <i *ngIf="selectedLog.response?.headers.length && responseHeadersCollapsed" class="material-icons">unfold_more</i>
+                    Headers ({{selectedLog?.response?.headers?.length}})
+                  </div>
+                  <div [ngbCollapse]="responseHeadersCollapsed">
+                    <div class="environment-logs-content-item" *ngFor="let header of selectedLog?.response?.headers">
+                      <strong>{{header.name | titlecase}}:</strong> {{header.value}}
+                    </div>
+                  </div>
+        
+                  <!-- Response Body -->
+                  <div *ngIf="selectedLog.response != null" class="environment-logs-content-title" (click)="responseBodyCollapsed = !responseBodyCollapsed">
+                    <i *ngIf="selectedLog.response?.body && !responseBodyCollapsed" class="material-icons">unfold_less</i>
+                    <i *ngIf="selectedLog.response?.body && responseBodyCollapsed" class="material-icons">unfold_more</i>
+                    Body ({{(!selectedLog.response?.body)?'none': 'raw'}})
+                  </div>
+                  <div [ngbCollapse]="responseBodyCollapsed">
+                    <div class="environment-logs-content-item pre">{{selectedLog.response?.body}}</div>
+                  </div>
+                </div>
+                <div *ngIf="selectedLog.response == null">
+                    <p class="message">No reponse yet</p>
+                </div>
+              </ng-template>
+            </ngb-tab>
+          </ngb-tabset>
+          
         </div>
       </div>
     </div>

--- a/src/app/components/environment-logs.component.html
+++ b/src/app/components/environment-logs.component.html
@@ -37,9 +37,9 @@
       <div class="col h-100 environment-logs-column">
         <div *ngIf="environmentsLogs[activeEnvironmentUUID][(selectedLogIndex$ | async)] as selectedLog"
           class="environment-logs-content pl-2 pr-2">
-          <ngb-tabset #t="ngbTabset">
+          <ngb-tabset #t="ngbTabset" (tabChange)="beforeTabChange($event)">
             <ngb-tab id="tab-request">
-              <ng-template ngbTabTitle>Request <i class="material-icons">call_made</i></ng-template>
+              <ng-template ngbTabTitle>Request <i class="material-icons">call_received</i></ng-template>
               <ng-template ngbTabContent>
                 <div class="environment-logs-content-title" (click)="generalCollapsed = !generalCollapsed">
                   <i *ngIf="!generalCollapsed" class="material-icons">unfold_less</i>
@@ -106,7 +106,7 @@
               </ng-template>
             </ngb-tab>
             <ngb-tab id="tab-response">
-              <ng-template ngbTabTitle>Response <i class="material-icons">call_received</i></ng-template>
+              <ng-template ngbTabTitle>Response <i class="material-icons">call_made</i></ng-template>
               <ng-template ngbTabContent>
                 <div *ngIf="selectedLog.response != null">
                   <!-- General Response -->

--- a/src/app/components/environment-logs.component.ts
+++ b/src/app/components/environment-logs.component.ts
@@ -17,6 +17,9 @@ export class EnvironmentLogsComponent implements OnInit {
   public routeParamsCollapsed: boolean;
   public queryParamsCollapsed: boolean;
   public bodyCollapsed: boolean;
+  public responseGeneralCollapsed: boolean;
+  public responseHeadersCollapsed: boolean;
+  public responseBodyCollapsed: boolean;
   public selectedLogIndex = new BehaviorSubject<number>(0);
   public selectedLogIndex$: Observable<number>;
 
@@ -53,5 +56,8 @@ export class EnvironmentLogsComponent implements OnInit {
     this.routeParamsCollapsed = false;
     this.queryParamsCollapsed = false;
     this.bodyCollapsed = true;
+    this.responseGeneralCollapsed = false;
+    this.responseHeadersCollapsed = false;
+    this.responseBodyCollapsed = false;
   }
 }

--- a/src/app/services/server.service.ts
+++ b/src/app/services/server.service.ts
@@ -308,16 +308,22 @@ export class ServerService {
         });
       };
 
+      const logErrorResponse = (err, req, res) => {
+        // the response is logged by the overrided function
+        res.status(504).send('Error occured while trying to proxy to: ' + req.url);
+      };
+
       server.use('*', proxy({
         target: environment.proxyHost,
         secure: false,
         changeOrigin: true,
         ssl: { ...httpsConfig, agent: false },
         onProxyReq: processRequest,
-        onProxyRes: logResponse
+        onProxyRes: logResponse,
+        onError: logErrorResponse
       }));
     } else {
-      //if not proxy, log the 404 response
+      // if not proxy, log the 404 response
       server.use(function(req, res, next) {
         // the send function is logging the response
         return res.status(404).send('Cannot ' + req.method + ' ' + req.url);
@@ -373,6 +379,7 @@ export class ServerService {
   private logErrorResponses(server: any, environment: Environment) {
     const self = this;
     server.use((err, req, res, next) => {
+      // the response is logged by the overrided function
       return res.status(500).send(err);
     });
   }

--- a/src/app/stores/reducer.ts
+++ b/src/app/stores/reducer.ts
@@ -36,7 +36,8 @@ export type ReducerActionType = {
   'REMOVE_TOAST' |
   'SET_USER_ID' |
   'UPDATE_SETTINGS'|
-  'LOG_RESPONSE';
+  'LOG_RESPONSE'|
+  'SET_ACTIVE_ENVIRONMENT_LOG_TAB';
   // used to select entities (environment, routes)
   UUID?: string;
   // item to add
@@ -661,6 +662,17 @@ export function environmentReducer(
         };
       }
 
+      break;
+    }
+
+    case 'SET_ACTIVE_ENVIRONMENT_LOG_TAB': {
+      const tab = action.item;
+      if ( tab != null ) {
+        newState = {
+          ...state,
+          activeEnvironmentLogsTab: tab
+        };
+      }
       break;
     }
 

--- a/src/app/stores/reducer.ts
+++ b/src/app/stores/reducer.ts
@@ -35,7 +35,8 @@ export type ReducerActionType = {
   'ADD_TOAST' |
   'REMOVE_TOAST' |
   'SET_USER_ID' |
-  'UPDATE_SETTINGS';
+  'UPDATE_SETTINGS'|
+  'LOG_RESPONSE';
   // used to select entities (environment, routes)
   UUID?: string;
   // item to add
@@ -640,6 +641,26 @@ export function environmentReducer(
         ...state,
         settings: { ...state.settings, ...action.properties as SettingsType }
       };
+      break;
+    }
+
+    case 'LOG_RESPONSE': {
+      if ( action.item != null ) {
+        const requestUuid = action.item.requestUuid;
+        const newEnvironmentsLogs = { ...state.environmentsLogs };
+
+        for (const item of newEnvironmentsLogs[action.UUID]) {
+          if (item.uuid === requestUuid) {
+            item.response = action.item;
+            break;
+          }
+        }
+        newState = {
+          ...state,
+          environmentsLogs: newEnvironmentsLogs
+        };
+      }
+
       break;
     }
 

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -12,6 +12,8 @@ export type ViewsNameType = 'ROUTE' | 'ENV_SETTINGS' | 'ENV_LOGS';
 
 export type TabsNameType = 'RESPONSE' | 'HEADERS' | 'RULES';
 
+export type EnvironmentLogsTabsNameType = 'REQUEST' | 'RESPONSE';
+
 export type EnvironmentStatusType = { running: boolean, needRestart: boolean };
 
 export type EnvironmentsStatusType = { [key: string]: EnvironmentStatusType };
@@ -21,6 +23,7 @@ export type DuplicatedRoutesTypes = { [key: string]: Set<string> };
 export type StoreType = {
   activeTab: TabsNameType;
   activeView: ViewsNameType;
+  activeEnvironmentLogsTab: EnvironmentLogsTabsNameType;
   activeEnvironmentUUID: string;
   activeRouteUUID: string;
   activeRouteResponseUUID: string;
@@ -40,6 +43,7 @@ export class Store {
   private store$ = new BehaviorSubject<StoreType>({
     activeView: 'ROUTE',
     activeTab: 'RESPONSE',
+    activeEnvironmentLogsTab: 'REQUEST',
     activeEnvironmentUUID: null,
     activeRouteUUID: null,
     activeRouteResponseUUID: null,

--- a/src/app/types/misc.type.ts
+++ b/src/app/types/misc.type.ts
@@ -1,3 +1,5 @@
+import { Request } from 'express';
+
 export type BannerConfigType = {
   id: string;
   enabled: boolean;
@@ -7,3 +9,7 @@ export type BannerConfigType = {
   styles?: { [key: string]: string };
   iconName?: string;
 };
+
+export interface IEnhancedRequest extends Request {
+  uuid: string;
+}

--- a/src/app/types/server.type.ts
+++ b/src/app/types/server.type.ts
@@ -4,6 +4,7 @@ export type ServerStateEventType = {
 };
 
 export type EnvironmentLogType = {
+  uuid: string;
   timestamp: Date;
   url: string;
   method: string;
@@ -14,8 +15,16 @@ export type EnvironmentLogType = {
   queryParams: { name: string, value: string }[];
   body: string;
   proxied: boolean;
+  response: EnvironmentLogResponse;
 };
 
 export type EnvironmentLogsType = { [key: string]: EnvironmentLogType[] };
 
 export type EnvironmentLogNameValuePairsType = { name: string, value: string }[];
+
+export type EnvironmentLogResponse = {
+  requestUuid: string;
+  status: number;
+  headers: { name: string, value: string }[];
+  body: string;
+};

--- a/test/environment-logs.spec.ts
+++ b/test/environment-logs.spec.ts
@@ -53,4 +53,14 @@ describe('Environment logs', () => {
     await tests.spectron.client.getText(`${environmentLogsItemSelector}:nth-child(2) .nav-link .route`).should.eventually.equal('GET\n/answer');
     await tests.spectron.client.waitForExist(`${environmentLogsItemSelector}:nth-child(2) .nav-link i[ngbTooltip="Request caught"]`);
   });
+
+  it('View response log', async () => {
+    await tests.spectron.client.element('#tab-response').click();
+    await tests.spectron.client.getText(`#tab-response-panel > div > div:nth-child(2)`).should.eventually.equal('Status: 404');
+  });
+
+  it('View request log again', async () => {
+    await tests.spectron.client.element('#tab-request').click();
+    await tests.spectron.client.getText(`#tab-request-panel > div:nth-child(2) > div:nth-child(1)`).should.eventually.equal('Request URL: /test');
+  });
 });


### PR DESCRIPTION
**Description**
I create two tabs in environment logs view: Request and Response. 
Each call have your request and response data logged in these tabs. 

**Related Issue**

This pull request implement the feature described in #138

**Motivation and Context**

This is described in #138

**How Has This Been Tested?**

I used the default Dev env environment and made all calls with firefox browser. 
I call /answer to test the mocked responses, /test to test the 404 error responses.
I create another environment with a /test route with the response (200, {}, timeout 5000), using 3001 port. I enable the Dev env proxy setting to the another environment (http://127.0.0.1:3001/). When I call /test on Dev env I can see the message "No response yet", and after 5 seconds I can see the response.
I stopped the other environment and called /test again, so I can see the response when I have an proxy error.

The code changes affect the express and proxy error messages (gateway timeout, route not found, internal error), I make handlers to can log these responses, so I override the error responses.

**Screenshots**

![Screenshot_20190908_161410](https://user-images.githubusercontent.com/6676601/64493230-d63dbe80-d253-11e9-879d-28b465d64d63.png)

**Closing issues**

closes #138
