### PR TITLE
Feature support route disabling

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -177,8 +177,13 @@
                         class="badge badge-default http-method-{{environmentRoute.method}} float-right">{{environmentRoute.method | uppercase}}</span>
                       /{{environmentRoute.endpoint}}
                     </div>
-                    <div class="menu-subtitle ellipsis">
-                      {{environmentRoute.documentation}}
+                    <div class="ellipsis">
+                      <div class="menu-subtitle">
+                        {{environmentRoute.documentation}}
+                      </div>
+                      <div *ngIf="environmentRoute.enabled==false">
+                        <span class="badge badge-danger route-disabled">DISABLED</span>
+                      </div>
                     </div>
                   </a>
                 </li>
@@ -351,10 +356,21 @@
                       </div>
                     </div>
 
-                    <!-- Documentation -->
                     <div class="row mt-2">
                       <div class="col">
+
+                        <!-- Enable/disable route -->
                         <div class="input-group">
+                          <div class="btn-group btn-group-toggle">
+                            <label class="btn" ngbButtonLabel
+                              [ngClass]="{'btn-danger': activeRouteForm.get('enabled').value == true, 'btn-success': activeRouteForm.get('enabled').value  == false}">
+                              <input type="checkbox" ngbButton formControlName="enabled"> 
+                              <span *ngIf="activeRouteForm.get('enabled').value == true">Disable</span>
+                              <span *ngIf="activeRouteForm.get('enabled').value  == false">Enable</span>
+                            </label>
+                          </div>
+
+                          <!-- Documentation -->
                           <input type="text" class="form-control" placeholder="Add notes or documentation" ValidPath
                             formControlName="documentation">
                         </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -362,7 +362,7 @@
                         <!-- Enable/disable route -->
                         <div class="input-group">
                           <div class="btn-group btn-group-toggle">
-                            <label class="btn" ngbButtonLabel
+                            <label class="btn btn-enable" ngbButtonLabel
                               [ngClass]="{'btn-danger': activeRouteForm.get('enabled').value == true, 'btn-success': activeRouteForm.get('enabled').value  == false}">
                               <input type="checkbox" ngbButton formControlName="enabled"> 
                               <span *ngIf="activeRouteForm.get('enabled').value == true">Disable</span>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -164,7 +164,7 @@
               <ul class="nav flex-column menu-list" #routesMenu dragula="routes"
                 [dragulaModel]="activeEnvironment.routes">
                 <li class="nav-item" *ngFor="let environmentRoute of activeEnvironment.routes">
-                  <a class="nav-link" [ngClass]="{'active': (activeRoute$ | async)?.uuid === environmentRoute.uuid}"
+                  <a class="nav-link" [ngClass]="{'active': (activeRoute$ | async)?.uuid === environmentRoute.uuid, 'route-disabled': !environmentRoute.enabled}"
                     (click)="selectRoute(environmentRoute.uuid)"
                     (contextmenu)="navigationContextMenu('route', environmentRoute.uuid, $event)">
                     <div class="ellipsis">
@@ -177,13 +177,8 @@
                         class="badge badge-default http-method-{{environmentRoute.method}} float-right">{{environmentRoute.method | uppercase}}</span>
                       /{{environmentRoute.endpoint}}
                     </div>
-                    <div class="ellipsis">
-                      <div class="menu-subtitle">
-                        {{environmentRoute.documentation}}
-                      </div>
-                      <div *ngIf="environmentRoute.enabled==false">
-                        <span class="badge badge-danger route-disabled">DISABLED</span>
-                      </div>
+                    <div class="menu-subtitle ellipsis">
+                      {{environmentRoute.documentation}}
                     </div>
                   </a>
                 </li>
@@ -356,21 +351,10 @@
                       </div>
                     </div>
 
+                    <!-- Documentation -->
                     <div class="row mt-2">
                       <div class="col">
-
-                        <!-- Enable/disable route -->
                         <div class="input-group">
-                          <div class="btn-group btn-group-toggle">
-                            <label class="btn btn-enable" ngbButtonLabel
-                              [ngClass]="{'btn-danger': activeRouteForm.get('enabled').value == true, 'btn-success': activeRouteForm.get('enabled').value  == false}">
-                              <input type="checkbox" ngbButton formControlName="enabled"> 
-                              <span *ngIf="activeRouteForm.get('enabled').value == true">Disable</span>
-                              <span *ngIf="activeRouteForm.get('enabled').value  == false">Enable</span>
-                            </label>
-                          </div>
-
-                          <!-- Documentation -->
                           <input type="text" class="form-control" placeholder="Add notes or documentation" ValidPath
                             formControlName="documentation">
                         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -203,7 +203,8 @@ export class AppComponent implements OnInit {
     this.activeRouteForm = this.formBuilder.group({
       documentation: [''],
       method: [''],
-      endpoint: ['']
+      endpoint: [''],
+      enabled: [true],
     });
 
     this.activeRouteResponseForm = this.formBuilder.group({
@@ -272,7 +273,8 @@ export class AppComponent implements OnInit {
       this.activeRouteForm.patchValue({
         documentation: activeRoute.documentation,
         method: activeRoute.method,
-        endpoint: activeRoute.endpoint
+        endpoint: activeRoute.endpoint,
+        enabled: activeRoute.enabled
       }, { emitEvent: false });
     });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -203,8 +203,7 @@ export class AppComponent implements OnInit {
     this.activeRouteForm = this.formBuilder.group({
       documentation: [''],
       method: [''],
-      endpoint: [''],
-      enabled: [true],
+      endpoint: ['']
     });
 
     this.activeRouteResponseForm = this.formBuilder.group({
@@ -273,8 +272,7 @@ export class AppComponent implements OnInit {
       this.activeRouteForm.patchValue({
         documentation: activeRoute.documentation,
         method: activeRoute.method,
-        endpoint: activeRoute.endpoint,
-        enabled: activeRoute.enabled
+        endpoint: activeRoute.endpoint
       }, { emitEvent: false });
     });
 
@@ -426,6 +424,13 @@ export class AppComponent implements OnInit {
   }
 
   /**
+   * Enable/disable a route
+   */
+  private toggleRoute(routeUUID?: string) {
+    this.environmentsService.toggleRoute(routeUUID);
+  }
+
+  /**
    * Remove environment and navigate depending on remaining environments
    */
   private removeEnvironment(environmentUUID?: string) {
@@ -544,6 +549,20 @@ export class AppComponent implements OnInit {
         ]
       };
 
+      if (subject === 'route') {
+        menu.items.push(
+          {
+            payload: {
+              subject,
+              action: 'toggle',
+              subjectUUID
+            },
+            label: 'Toggle Route',
+            icon: 'power_settings_new'
+          }
+        );
+      }
+
       if (subject === 'environment') {
         menu.items.unshift(
           {
@@ -604,6 +623,11 @@ export class AppComponent implements OnInit {
           this.removeRoute(payload.subjectUUID);
         } else if (payload.subject === 'environment') {
           this.removeEnvironment(payload.subjectUUID);
+        }
+        break;
+      case 'toggle':
+        if (payload.subject === 'route') {
+          this.toggleRoute(payload.subjectUUID);
         }
         break;
     }

--- a/src/app/components/context-menu.component.ts
+++ b/src/app/components/context-menu.component.ts
@@ -4,7 +4,7 @@ import { DataSubjectType } from 'src/app/types/data.type';
 
 export type ContextMenuItemPayload = {
   subject: DataSubjectType;
-  action: 'delete' | 'duplicate' | 'env_settings' | 'env_logs' | 'export';
+  action: 'delete' | 'duplicate' | 'env_settings' | 'env_logs' | 'export' | 'toggle';
   subjectUUID: string;
 };
 

--- a/src/app/libs/migrations.lib.ts
+++ b/src/app/libs/migrations.lib.ts
@@ -151,5 +151,17 @@ export const Migrations: { id: number, migrationFunction: (environment: Environm
         });
       });
     }
+  },
+
+  /**
+   * Create a "enabled" param
+   */
+  {
+    id: 8,
+    migrationFunction: (environment: Environment) => {
+      environment.routes.forEach((route: Route) => {
+        route.enabled = true;
+      });
+    }
   }
 ];

--- a/src/app/services/environments.service.ts
+++ b/src/app/services/environments.service.ts
@@ -693,7 +693,7 @@ export class EnvironmentsService {
         method: log.method.toLowerCase() as Method,
         endpoint: log.url.slice(1), // Remove the initial slash '/'
         responses: [response],
-        active: true
+        enabled: true
       };
       this.store.update(addRouteAction(newRoute));
 

--- a/src/app/services/environments.service.ts
+++ b/src/app/services/environments.service.ts
@@ -48,7 +48,8 @@ export class EnvironmentsService {
     documentation: '',
     method: 'get',
     endpoint: '',
-    responses: []
+    responses: [],
+    enabled: true
   };
 
   private routeResponseSchema: RouteResponse = {
@@ -692,6 +693,7 @@ export class EnvironmentsService {
         method: log.method.toLowerCase() as Method,
         endpoint: log.url.slice(1), // Remove the initial slash '/'
         responses: [response],
+        active: true
       };
       this.store.update(addRouteAction(newRoute));
 

--- a/src/app/services/environments.service.ts
+++ b/src/app/services/environments.service.ts
@@ -253,6 +253,19 @@ export class EnvironmentsService {
   }
 
   /**
+   * Enable and disable a route
+   */
+  public toggleRoute(routeUUID?: string) {
+    const selectedRoute = this.store.getActiveEnvironment().routes.find(route => route.uuid === routeUUID);
+    if (selectedRoute) {
+      this.store.update(updateRouteAction({
+        uuid: selectedRoute.uuid,
+        enabled: !selectedRoute.enabled
+      }));
+    }
+  }
+
+  /**
    * Set active tab
    */
   public setActiveTab(activeTab: TabsNameType) {

--- a/src/app/services/server.service.ts
+++ b/src/app/services/server.service.ts
@@ -152,7 +152,7 @@ export class ServerService {
       const duplicatedRoutes = this.store.get('duplicatedRoutes')[environment.uuid];
 
       // only launch non duplicated routes
-      if ((!duplicatedRoutes || !duplicatedRoutes.has(declaredRoute.uuid)) && declaredRoute.enabled !== false) {
+      if ((!duplicatedRoutes || !duplicatedRoutes.has(declaredRoute.uuid)) && declaredRoute.enabled) {
         try {
           // create route
           server[declaredRoute.method]('/' + ((environment.endpointPrefix) ? environment.endpointPrefix + '/' : '') + declaredRoute.endpoint.replace(/ /g, '%20'), (req, res) => {

--- a/src/app/services/server.service.ts
+++ b/src/app/services/server.service.ts
@@ -152,7 +152,7 @@ export class ServerService {
       const duplicatedRoutes = this.store.get('duplicatedRoutes')[environment.uuid];
 
       // only launch non duplicated routes
-      if (!duplicatedRoutes || !duplicatedRoutes.has(declaredRoute.uuid)) {
+      if ((!duplicatedRoutes || !duplicatedRoutes.has(declaredRoute.uuid)) && declaredRoute.enabled !== false) {
         try {
           // create route
           server[declaredRoute.method]('/' + ((environment.endpointPrefix) ? environment.endpointPrefix + '/' : '') + declaredRoute.endpoint.replace(/ /g, '%20'), (req, res) => {

--- a/src/app/stores/reducer.ts
+++ b/src/app/stores/reducer.ts
@@ -449,7 +449,7 @@ export function environmentReducer(
     }
 
     case ActionTypes.UPDATE_ROUTE: {
-      const propertiesNeedingRestart: (keyof Route)[] = ['endpoint', 'method'];
+      const propertiesNeedingRestart: (keyof Route)[] = ['endpoint', 'method', 'enabled'];
       const activeEnvironmentStatus = state.environmentsStatus[state.activeEnvironmentUUID];
       let needRestart: boolean;
 

--- a/src/app/stores/reducer.ts
+++ b/src/app/stores/reducer.ts
@@ -466,6 +466,7 @@ export function environmentReducer(
       const propertiesNeedingRestart: (keyof Route)[] = ['endpoint', 'method', 'enabled'];
       const activeEnvironmentStatus = state.environmentsStatus[state.activeEnvironmentUUID];
       let needRestart: boolean;
+      const specifiedUUID = action.properties.uuid;
 
       if (activeEnvironmentStatus.needRestart) {
         needRestart = true;
@@ -480,7 +481,14 @@ export function environmentReducer(
             return {
               ...environment,
               routes: environment.routes.map(route => {
-                if (route.uuid === state.activeRouteUUID) {
+                if (specifiedUUID) {
+                  if (route.uuid === specifiedUUID) {
+                    return {
+                      ...route,
+                      ...action.properties,
+                    };
+                  }
+                } else if (route.uuid === state.activeRouteUUID) {
                   return {
                     ...route,
                     ...action.properties,

--- a/src/app/types/route.type.ts
+++ b/src/app/types/route.type.ts
@@ -258,6 +258,7 @@ export type Route = {
   method: Method;
   endpoint: string;
   responses: RouteResponse[];
+  enabled: boolean;
 };
 
 export type Header = { key: string, value: string };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -331,6 +331,13 @@ $http-methods: ('get', $blue), ('put', $orange), ('post', $green), ('delete', $r
   }
 }
 
+.badge {
+  &.route-disabled {
+    float: right;
+    overflow: auto;
+  }
+}
+
 .header {
   background-color: lighten($gray-900, 3%);
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,6 +35,14 @@
     box-shadow: inset 2px 0 0 0 $blue;
     background-color: $component-active-bg;
   }
+  .nav-link.route-disabled,
+  .nav-item.show .nav-link {
+    box-shadow: inset -2px 0 0 0 $red;
+  }
+  .nav-link.route-disabled.active,
+  .nav-item.show .nav-link {
+    box-shadow: inset -2px 0 0 0 $red, inset 2px 0 0 0 $blue;
+  }
   .nav-link.running {
     box-shadow: inset -3px 0 0 0 $green;
   }
@@ -333,13 +341,6 @@ $http-methods: ('get', $blue), ('put', $orange), ('post', $green), ('delete', $r
   .http-method-#{nth($method, 1)} {
     background-color: #{nth($method, 2)};
     color: $gray-900;
-  }
-}
-
-.badge {
-  &.route-disabled {
-    float: right;
-    overflow: auto;
   }
 }
 

--- a/test/data/basic-data/environments.json
+++ b/test/data/basic-data/environments.json
@@ -11,6 +11,7 @@
         "method": "get",
         "endpoint": "*/:var/a(b)?c/[0-9]{1,5}",
         "documentation": "Test documentation",
+        "enabled": true,
         "responses": [
           {
             "uuid": "505a77b1-34c7-4af8-adde-ed00b8dd29bf",
@@ -34,6 +35,7 @@
         "method": "get",
         "endpoint": "answer",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "057ec98a-dd5d-4dd8-9af9-a99dd7a5c3f5",
@@ -57,6 +59,7 @@
         "method": "post",
         "endpoint": "dolphins",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "6d3abb6f-6705-4588-8b09-337ddc4ae33c",

--- a/test/data/basic-data/settings.json
+++ b/test/data/basic-data/settings.json
@@ -1,5 +1,5 @@
 {
   "welcomeShown": true,
   "analytics": true,
-  "lastMigration": 6
+  "lastMigration": 8
 }

--- a/test/data/dev/environments.json
+++ b/test/data/dev/environments.json
@@ -11,6 +11,7 @@
         "method": "get",
         "endpoint": "*/:var/a(b)?c/[0-9]{1,5}",
         "documentation": "Test documentation",
+        "enabled": true,
         "responses": [
           {
             "uuid": "a6092eb3-5e0c-42f1-beb3-a545056c070d",
@@ -34,6 +35,7 @@
         "method": "get",
         "endpoint": "answer",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "184a72a5-06d8-4875-b2a5-64977e1669ad",
@@ -57,6 +59,7 @@
         "method": "post",
         "endpoint": "dolphins",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "cea5910c-068f-4418-9162-f94097a17987",

--- a/test/data/dev/settings.json
+++ b/test/data/dev/settings.json
@@ -2,5 +2,5 @@
   "welcomeShown": true,
   "analytics": true,
   "bannerDismissed": [],
-  "lastMigration": 6
+  "lastMigration": 8
 }

--- a/test/data/first-load/settings.json
+++ b/test/data/first-load/settings.json
@@ -1,5 +1,5 @@
 {
   "welcomeShown": false,
   "analytics": true,
-  "lastMigration": 6
+  "lastMigration": 8
 }

--- a/test/data/proxy/environments.json
+++ b/test/data/proxy/environments.json
@@ -11,6 +11,7 @@
             "method": "get",
             "endpoint": "*/:var/a(b)?c/[0-9]{1,5}",
             "documentation": "Test documentation",
+            "enabled": true,
             "responses": [
                 {
                     "uuid": "505a77b1-34c7-4af8-adde-ed00b8dd29bf",
@@ -34,6 +35,7 @@
             "method": "get",
             "endpoint": "answer",
             "documentation": "",
+            "enabled": true,
             "responses": [
                 {
                     "uuid": "057ec98a-dd5d-4dd8-9af9-a99dd7a5c3f5",
@@ -57,6 +59,7 @@
             "method": "post",
             "endpoint": "dolphins",
             "documentation": "",
+            "enabled": true,
             "responses": [
                 {
                     "uuid": "6d3abb6f-6705-4588-8b09-337ddc4ae33c",

--- a/test/data/proxy/settings.json
+++ b/test/data/proxy/settings.json
@@ -1,5 +1,5 @@
 {
   "welcomeShown": true,
   "analytics": true,
-  "lastMigration": 6
+  "lastMigration": 8
 }

--- a/test/data/responses-rules/environments.json
+++ b/test/data/responses-rules/environments.json
@@ -11,6 +11,7 @@
         "method": "get",
         "endpoint": "users/:userid",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "68461303-b003-475b-95aa-5f2b19252baf",
@@ -34,6 +35,7 @@
         "method": "get",
         "endpoint": "rules/:id",
         "documentation": "",
+        "enabled": true,
         "responses": [
           {
             "uuid": "0d37217f-badc-4cbd-8ec8-61d693cf91aa",

--- a/test/data/responses-rules/settings.json
+++ b/test/data/responses-rules/settings.json
@@ -1,5 +1,5 @@
 {
   "welcomeShown": true,
   "analytics": true,
-  "lastMigration": 6
+  "lastMigration": 8
 }

--- a/test/enable-disabling-routes.spec.ts
+++ b/test/enable-disabling-routes.spec.ts
@@ -31,12 +31,14 @@ describe('Enable/disable routes', () => {
   });
 
   it('Call untouched route', async () => {
+    await tests.helpers.selectRoute(2);
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled', null, true);
     await tests.helpers.httpCallAsserterWithPort(getAnswerCall[0], 3000);
   });
 
   it('Disabling route /answer', async () => {
-    await tests.helpers.selectRoute(2);
     await tests.helpers.disableRoute();
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled');
     await tests.helpers.restartEnvironment();
   });
 
@@ -44,8 +46,9 @@ describe('Enable/disable routes', () => {
     await tests.helpers.httpCallAsserterWithPort(getAnswerCall[1], 3000);
   });
 
-  it('Renable route', async () => {
+  it('Re-enable route', async () => {
     await tests.helpers.disableRoute();
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled', null, true);
     await tests.helpers.restartEnvironment();
   });
 

--- a/test/enable-disabling-routes.spec.ts
+++ b/test/enable-disabling-routes.spec.ts
@@ -1,0 +1,55 @@
+import { Tests } from './lib/tests';
+import { HttpCall } from './lib/types';
+
+const tests = new Tests('basic-data');
+
+const getAnswerCall: HttpCall[] = [
+  {
+    description: 'Call GET answer',
+    path: '/answer',
+    method: 'GET',
+    testedProperties: {
+      body: '42',
+      status: 200
+    }
+  }, {
+    description: 'Call GET answer',
+    path: '/answer',
+    method: 'GET',
+    testedProperties: {
+      body: 'Cannot GET /answer',
+      status: 404
+    }
+  }
+];
+
+describe('Enable/disable routes', () => {
+  tests.runHooks();
+
+  it('Enabling environment', async () => {
+    await tests.helpers.startEnvironment();
+  });
+
+  it('Call untouched route', async () => {
+    await tests.helpers.httpCallAsserterWithPort(getAnswerCall[0], 3000);
+  });
+
+  it('Disabling route /answer', async () => {
+    await tests.helpers.selectRoute(2);
+    await tests.helpers.disableRoute();
+    await tests.helpers.restartEnvironment();
+  });
+
+  it('Call disabled route', async () => {
+    await tests.helpers.httpCallAsserterWithPort(getAnswerCall[1], 3000);
+  });
+
+  it('Renable route', async () => {
+    await tests.helpers.disableRoute();
+    await tests.helpers.restartEnvironment();
+  });
+
+  it('Call reenabled route', async () => {
+    await tests.helpers.httpCallAsserterWithPort(getAnswerCall[0], 3000);
+  });
+});

--- a/test/enable-disabling-routes.spec.ts
+++ b/test/enable-disabling-routes.spec.ts
@@ -32,13 +32,13 @@ describe('Enable/disable routes', () => {
 
   it('Call untouched route', async () => {
     await tests.helpers.selectRoute(2);
-    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled', null, true);
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active.route-disabled', null, true);
     await tests.helpers.httpCallAsserterWithPort(getAnswerCall[0], 3000);
   });
 
   it('Disabling route /answer', async () => {
     await tests.helpers.disableRoute();
-    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled');
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active.route-disabled');
     await tests.helpers.restartEnvironment();
   });
 
@@ -48,7 +48,7 @@ describe('Enable/disable routes', () => {
 
   it('Re-enable route', async () => {
     await tests.helpers.disableRoute();
-    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active .route-disabled', null, true);
+    await tests.spectron.client.waitForExist('.menu-column--routes .menu-list .nav-item .nav-link.active.route-disabled', null, true);
     await tests.helpers.restartEnvironment();
   });
 

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -44,6 +44,12 @@ export class Helpers {
       .should.eventually.have.property('value').to.be.an('Array').that.have.lengthOf(expected);
   }
 
+  async contextMenuClick(targetMenuItemSelector: string, contextMenuItemIndex: number) {
+    await this.testsInstance.spectron.client.element(targetMenuItemSelector).rightClick();
+
+    await this.testsInstance.spectron.client.element(`.context-menu .context-menu-item:nth-child(${contextMenuItemIndex})`).click();
+  }
+
   async contextMenuClickAndConfirm(targetMenuItemSelector: string, contextMenuItemIndex: number) {
     await this.testsInstance.spectron.client.element(targetMenuItemSelector).rightClick();
 
@@ -134,6 +140,6 @@ export class Helpers {
   }
 
   async disableRoute() {
-    await this.testsInstance.spectron.client.element('.main-content .btn-enable').click();
+    await this.contextMenuClick('.menu-column--routes .menu-list .nav-item .nav-link.active', 4);
   }
 }

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -62,6 +62,11 @@ export class Helpers {
     await this.testsInstance.spectron.client.waitForExist(`.menu-column--environments .menu-list .nav-item .nav-link.active.running`, 1000, true);
   }
 
+  async restartEnvironment() {
+    await this.testsInstance.spectron.client.element('.btn i[ngbtooltip="Server needs restart"]').click();
+    await this.testsInstance.spectron.client.waitForExist(`.menu-column--environments .menu-list .nav-item .nav-link.active.running`);
+  }
+
   async selectEnvironment(index: number)  {
     await this.testsInstance.spectron.client.element(`.menu-column--environments .menu-list .nav-item:nth-child(${index}) .nav-link`).click();
   }
@@ -122,5 +127,9 @@ export class Helpers {
 
   async httpCallAsserter(httpCall: HttpCall) {
     await this.httpCallAsserterWithPort(httpCall, 3000);
+  }
+
+  async disableRoute() {
+    await this.testsInstance.spectron.client.element('.main-content .btn-enable').click();
   }
 }

--- a/test/routes-create-delete.spec.ts
+++ b/test/routes-create-delete.spec.ts
@@ -22,7 +22,7 @@ describe('Create and delete routes', () => {
   });
 
   it('Last added route should remain and be active', async () => {
-    await tests.spectron.client.getText('.menu-column--routes .menu-list .nav-item:first-of-type .nav-link.active div:first-of-type').should.eventually.equal('GET\n/');
+    await tests.spectron.client.getText('.menu-column--routes .menu-list .nav-item:first-of-type .nav-link.active .ellipsis:first-child').should.eventually.equal('GET\n/');
   });
 
   it('Remove last route, active tab should be environment settings', async () => {


### PR DESCRIPTION
**Description**
Implements a feature do disable/enable a route. When
Issue #106 

**How Has This Been Tested?**
I use the basic-data environment, start the environment and made a call to "/anwser". Then I disable the route, restart the server and made another call to "/answer", now the route is not caught. I enable the route and restart the server again and made the call, the route is caught.

**Screenshots**
![Screenshot_20191026_210117](https://user-images.githubusercontent.com/6676601/67627518-dc075780-f833-11e9-8de5-f073dd3e0b93.png)
![Screenshot_20191026_210140](https://user-images.githubusercontent.com/6676601/67627519-dd388480-f833-11e9-8f88-042fd1c3b02a.png)

**Closing issues**
Closes #106 
