### PR TITLE
Generate a unused port to a new environment

### DIFF
--- a/src/app/services/environments.service.ts
+++ b/src/app/services/environments.service.ts
@@ -154,6 +154,8 @@ export class EnvironmentsService {
 
       newEnvironment = this.renewUUIDs(newEnvironment, 'environment') as Environment;
 
+      newEnvironment.port = this.store.getNewEnvironmentPort();
+
       this.store.update(addEnvironmentAction(newEnvironment));
 
       this.eventsService.analyticsEvents.next(AnalyticsEvents.DUPLICATE_ENVIRONMENT);
@@ -331,7 +333,7 @@ export class EnvironmentsService {
       ...this.environmentSchema,
       uuid: uuid(),
       name: 'New environment',
-      port: 3000,
+      port: this.store.getNewEnvironmentPort(),
       routes: [
         {
           ...this.routeSchema,

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -173,41 +173,20 @@ export class Store {
   }
 
   /**
-   * Generate a unused port to a new environment
-   */
-  public getNewEnvironmentPort(): number {
-    const usedPorts: number[] = [];
-    this.store$.value.environments.forEach((environment) => {
-      usedPorts.push(environment.port);
-    });
-
-    const activeEnvironment: Environment = this.getActiveEnvironment();
-    let testSelectedPort: number;
-    if (activeEnvironment == null) {
-      testSelectedPort = 3000;
-    } else {
-      testSelectedPort = activeEnvironment.port;
-    }
-    for (let i = 0; i < 10; i++) {
-      if (!usedPorts.includes(testSelectedPort)) {
-        return testSelectedPort;
-      }
-      testSelectedPort++;
-    }
-
-    const min = Math.ceil(1024);
-    const max = Math.floor(65535);
-    do {
-      testSelectedPort = Math.floor(Math.random() * (max - min)) + min;
-    } while (usedPorts.includes(testSelectedPort));
-
-    return testSelectedPort;
-  }
-
-  /**
    * Update the store using the reducer
    */
   public update(action: Actions) {
     this.store$.next(environmentReducer(this.store$.value, action));
+  }
+
+  /**
+   * Get a list with all environment ports
+   */
+  public getEnvironmentsPorts(): number[] {
+    return this.store$.value.environments.reduce((list, env) => {
+      list.push(env.port);
+
+      return list;
+    }, []);
   }
 }

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -173,6 +173,38 @@ export class Store {
   }
 
   /**
+   * Generate a unused port to a new environment
+   */
+  public getNewEnvironmentPort(): number {
+    const usedPorts: number[] = [];
+    this.store$.value.environments.forEach((environment) => {
+      usedPorts.push(environment.port);
+    });
+
+    const activeEnvironment: Environment = this.getActiveEnvironment();
+    let testSelectedPort: number;
+    if (activeEnvironment == null) {
+      testSelectedPort = 3000;
+    } else {
+      testSelectedPort = activeEnvironment.port;
+    }
+    for (let i = 0; i < 10; i++) {
+      testSelectedPort++;
+      if (!usedPorts.includes(testSelectedPort)) {
+        return testSelectedPort;
+      }
+    }
+
+    const min = Math.ceil(1024);
+    const max = Math.floor(65535);
+    do {
+      testSelectedPort = Math.floor(Math.random() * (max - min)) + min;
+    } while (usedPorts.includes(testSelectedPort));
+
+    return testSelectedPort;
+  }
+
+  /**
    * Update the store using the reducer
    */
   public update(action: Actions) {

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -189,10 +189,10 @@ export class Store {
       testSelectedPort = activeEnvironment.port;
     }
     for (let i = 0; i < 10; i++) {
-      testSelectedPort++;
       if (!usedPorts.includes(testSelectedPort)) {
         return testSelectedPort;
       }
+      testSelectedPort++;
     }
 
     const min = Math.ceil(1024);

--- a/test/environments-create-delete.spec.ts
+++ b/test/environments-create-delete.spec.ts
@@ -8,6 +8,7 @@ describe('Create and delete environments', () => {
   it('Add an environment', async () => {
     await tests.helpers.countEnvironments(1);
     await tests.helpers.addEnvironment();
+    await tests.helpers.assertActiveEnvironmentPort(3001);
     await tests.helpers.countEnvironments(2);
   });
 
@@ -28,5 +29,15 @@ describe('Create and delete environments', () => {
     await tests.helpers.countRoutes(0);
 
     await tests.spectron.client.waitForExist('.header input[placeholder="No environment"]');
+  });
+
+  it('Add ten environments ever clicking in the first', async () => {
+    let port = 3000;
+    for (let i = 0; i < 10; i++) {
+      await tests.helpers.addEnvironment();
+      await tests.helpers.assertActiveEnvironmentPort(port);
+      await tests.helpers.selectEnvironment(1);
+      port++;
+    }
   });
 });

--- a/test/environments-create-delete.spec.ts
+++ b/test/environments-create-delete.spec.ts
@@ -32,12 +32,10 @@ describe('Create and delete environments', () => {
   });
 
   it('Add ten environments ever clicking in the first', async () => {
-    let port = 3000;
-    for (let i = 0; i < 10; i++) {
+    for (let port = 3000; port < 3010; port++) {
       await tests.helpers.addEnvironment();
       await tests.helpers.assertActiveEnvironmentPort(port);
       await tests.helpers.selectEnvironment(1);
-      port++;
     }
   });
 });

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -134,7 +134,7 @@ export class Helpers {
   }
 
   async assertActiveEnvironmentPort(expectedPort: number) {
-    const val: String = await this.testsInstance.spectron.client.element('input[formcontrolname="port"]').getAttribute('value');
-    await val.should.be.equals(expectedPort.toString());
+    const port: String = await this.testsInstance.spectron.client.element('input[formcontrolname="port"]').getAttribute('value');
+    await port.should.be.equals(expectedPort.toString());
   }
 }

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -132,4 +132,9 @@ export class Helpers {
   async httpCallAsserter(httpCall: HttpCall) {
     await this.httpCallAsserterWithPort(httpCall, 3000);
   }
+
+  async assertActiveEnvironmentPort(expectedPort: number) {
+    let val: String = await this.testsInstance.spectron.client.element('input[formcontrolname="port"]').getAttribute("value");
+    await val.should.be.equals(expectedPort.toString());
+  }
 }

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -134,7 +134,7 @@ export class Helpers {
   }
 
   async assertActiveEnvironmentPort(expectedPort: number) {
-    let val: String = await this.testsInstance.spectron.client.element('input[formcontrolname="port"]').getAttribute("value");
+    const val: String = await this.testsInstance.spectron.client.element('input[formcontrolname="port"]').getAttribute('value');
     await val.should.be.equals(expectedPort.toString());
   }
 }


### PR DESCRIPTION
**Description**

On create or duplicate an environment it's generate a new unused port to it. The port is chosen based on the active environment port. If any of the ten next ports is unused by an environment, this port is chosen. Else a random unused port is generated. The default port, when there's no environments, remains the 3000.

**Related Issue**

Issue #192

**How Has This Been Tested?**

I tested creating a environment if when there's no environments. Creating and duplicating more than ten environments selecting the first on any new environment.

**Screenshots (if appropriate):**

![image](https://user-images.githubusercontent.com/6676601/67910099-3a984280-fb60-11e9-9ea6-68c3a3a745a6.png)

**Closing issues**

Closes #192 
