### PR TITLE
Feature/variable log body size limit

### DIFF
--- a/src/app/components/settings-modal.component.html
+++ b/src/app/components/settings-modal.component.html
@@ -8,6 +8,14 @@
       <label class="custom-control-label" for="analytics">I agree to share anonymous usage data</label>
     </div>
     <p class="text-muted"><small>We are using a basic Google Analytics setup, none of your data/content is kept anywhere and it helps us improve Mockoon :)</small></p>
+
+    <div>
+      <label for="log-body-size">Log body size:</label>
+      <input type="number" class="form-control col-4" id="log-body-size"
+          ngbTooltip="Log's body size" min="1"
+          placeholder="10000 (default)" digitOnly 
+          [ngModel]="(settings$ | async)?.logSizeLimit" (ngModelChange)="settingsUpdated($event, 'logSizeLimit')">
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-primary" (click)="close()">Close</button>

--- a/src/app/components/settings-modal.component.html
+++ b/src/app/components/settings-modal.component.html
@@ -9,8 +9,9 @@
     </div>
     <p class="text-muted"><small>We are using a basic Google Analytics setup, none of your data/content is kept anywhere and it helps us improve Mockoon :)</small></p>
 
-    <div>
+    <div class="form-group log-body">
       <label for="log-body-size">Log body size:</label>
+      <p class="text-muted"><small>Truncate the entering requests and exiting responses bodies if bigger (characters).</small></p>
       <input type="number" class="form-control col-4" id="log-body-size"
           ngbTooltip="Log's body size" min="1"
           placeholder="10000 (default)" digitOnly 

--- a/src/app/components/settings-modal.component.scss
+++ b/src/app/components/settings-modal.component.scss
@@ -7,3 +7,13 @@ input[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none; 
     margin: 0; 
 }
+
+.log-body {
+    label {
+        margin-bottom: 0;
+    }
+
+    p {
+        margin-bottom: 10px;
+    }
+}

--- a/src/app/components/settings-modal.component.scss
+++ b/src/app/components/settings-modal.component.scss
@@ -1,0 +1,9 @@
+input[type="number"] {
+    -moz-appearance: textfield;
+}
+
+input[type="number"]::-webkit-inner-spin-button, 
+input[type="number"]::-webkit-outer-spin-button { 
+    -webkit-appearance: none; 
+    margin: 0; 
+}

--- a/src/app/components/settings-modal.component.ts
+++ b/src/app/components/settings-modal.component.ts
@@ -7,7 +7,8 @@ import { Store } from 'src/app/stores/store';
 
 @Component({
   selector: 'app-settings-modal',
-  templateUrl: './settings-modal.component.html'
+  templateUrl: './settings-modal.component.html',
+  styleUrls: ['settings-modal.component.scss']
 })
 export class SettingsModalComponent implements OnInit, AfterViewInit {
   @ViewChild('modal', { static: false }) modal: ElementRef;

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -6,6 +6,7 @@ import { DataSubjectType, ExportType } from 'src/app/types/data.type';
 import { Environment, Environments } from 'src/app/types/environment.type';
 import { Route } from 'src/app/types/route.type';
 import { EnvironmentLog, EnvironmentLogResponse } from 'src/app/types/server.type';
+import { Store } from 'src/app/stores/store';
 import * as url from 'url';
 const appVersion = require('../../../package.json').version;
 
@@ -13,7 +14,7 @@ const appVersion = require('../../../package.json').version;
 export class DataService {
   private exportId = 'mockoon_export';
 
-  constructor() { }
+  constructor(private store: Store) { }
 
   /**
    * Wrap data to export in Mockoon export format
@@ -52,6 +53,7 @@ export class DataService {
    */
   public formatRequestLog(request: any): EnvironmentLog {
     // use some getter to keep the scope because some request properties are being defined later by express (route, params, etc)
+    const maxLength = this.store.get('settings').logSizeLimit;
     const requestLog: EnvironmentLog = {
       uuid: request.uuid,
       timestamp: new Date(),
@@ -84,7 +86,6 @@ export class DataService {
         return [];
       },
       get body() {
-        const maxLength = 10000;
         let truncatedBody: string = request.body;
 
         // truncate
@@ -131,8 +132,8 @@ export class DataService {
       return { name: headerName, value: headers[headerName] };
     }).sort(AscSort);
 
+    const maxLength = this.store.get('settings').logSizeLimit;
     responseLog.body = function () {
-      const maxLength = 10000;
       let truncatedBody: string = body;
 
       // truncate

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -10,6 +10,7 @@ export type Settings = {
   analytics: boolean;
   lastMigration: number;
   bannerDismissed: string[];
+  logSizeLimit: number;
 };
 
 export type SettingsProperties = { [T in keyof Settings]?: Settings[T] };
@@ -20,7 +21,8 @@ export class SettingsService {
     welcomeShown: false,
     analytics: true,
     lastMigration: 0,
-    bannerDismissed: []
+    bannerDismissed: [],
+    logSizeLimit: 10000
   };
   private storageKey = 'settings';
 

--- a/test/environments-create-delete.spec.ts
+++ b/test/environments-create-delete.spec.ts
@@ -9,6 +9,7 @@ describe('Create and delete environments', () => {
     await tests.helpers.countEnvironments(1);
     await tests.helpers.addEnvironment();
     await tests.helpers.countEnvironments(2);
+    await tests.helpers.assertActiveEnvironmentPort(3001);
   });
 
   it('Remove first environment', async () => {
@@ -28,5 +29,15 @@ describe('Create and delete environments', () => {
     await tests.helpers.countRoutes(0);
 
     await tests.spectron.client.waitForExist('.header input[placeholder="No environment"]');
+  });
+
+  it('Add ten environments ever clicking in the first', async() => {
+    let port = 3000;
+    for (let i = 0; i < 10; i++) {
+      await tests.helpers.addEnvironment();
+      await tests.helpers.assertActiveEnvironmentPort(port);
+      await tests.helpers.selectEnvironment(1);
+      port++;
+    }
   });
 });

--- a/test/environments-create-delete.spec.ts
+++ b/test/environments-create-delete.spec.ts
@@ -9,7 +9,6 @@ describe('Create and delete environments', () => {
     await tests.helpers.countEnvironments(1);
     await tests.helpers.addEnvironment();
     await tests.helpers.countEnvironments(2);
-    await tests.helpers.assertActiveEnvironmentPort(3001);
   });
 
   it('Remove first environment', async () => {
@@ -29,15 +28,5 @@ describe('Create and delete environments', () => {
     await tests.helpers.countRoutes(0);
 
     await tests.spectron.client.waitForExist('.header input[placeholder="No environment"]');
-  });
-
-  it('Add ten environments ever clicking in the first', async() => {
-    let port = 3000;
-    for (let i = 0; i < 10; i++) {
-      await tests.helpers.addEnvironment();
-      await tests.helpers.assertActiveEnvironmentPort(port);
-      await tests.helpers.selectEnvironment(1);
-      port++;
-    }
   });
 });

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -123,4 +123,18 @@ export class Helpers {
   async httpCallAsserter(httpCall: HttpCall) {
     await this.httpCallAsserterWithPort(httpCall, 3000);
   }
+
+  async openSettingsModal() {
+    await this.testsInstance.spectron.webContents.send('keydown', { action: 'OPEN_SETTINGS' });
+    await this.testsInstance.spectron.client.waitForExist(`.modal-dialog`);
+  }
+
+  async closeSettingsModal() {
+    await this.testsInstance.spectron.client.element(`.modal-dialog .modal-footer button`).click();
+  }
+
+  async requestLogBodyContains(str: string) {
+    await this.testsInstance.spectron.client.element(`div.environment-logs-content-title:nth-child(9)`).click();
+    await this.testsInstance.spectron.client.element(`div.environment-logs-content-item.pre`).getHTML().should.eventually.contain(str);
+  }
 }

--- a/test/settings.spec.ts
+++ b/test/settings.spec.ts
@@ -1,0 +1,83 @@
+import { Tests } from './lib/tests';
+import { HttpCall } from './lib/types';
+
+const tests = new Tests('basic-data');
+
+function generateCall(requestBody: any): HttpCall {
+  return {
+    description: 'Call POST dolphins',
+    path: '/dolphins',
+    method: 'POST',
+    body: requestBody,
+    testedProperties: {
+      body: '{"response":"So Long, and Thanks for All the Fish"}',
+      status: 200
+    }
+  };
+}
+
+function makeString(length: number): string {
+  let result           = '';
+  const characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  for ( let i = 0; i < length; i++ ) {
+     result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+}
+
+const inputBodySize = `.modal-dialog input[ngbTooltip="Log's body size"]`;
+
+describe('Settings Dialog', () => {
+  tests.runHooks();
+
+  it('Start the environment', async () => {
+    await tests.helpers.startEnvironment();
+    await tests.helpers.switchViewInHeader('ENV_LOGS');
+  });
+
+  describe('Log variable size', () => {
+
+    it('Set size to 100', async () => {
+      await tests.helpers.openSettingsModal();
+      await tests.spectron.client.element(inputBodySize).setValue('100');
+      await tests.helpers.closeSettingsModal();
+    });
+
+    it('The size is 100, do not truncate on 99', async () => {
+      const str = makeString(99);
+      await tests.helpers.httpCallAsserter(generateCall(str));
+      await tests.helpers.countEnvironmentLogsEntries(1);
+      await tests.helpers.requestLogBodyContains(str);
+    });
+
+    it('The default size is 100, do truncate on 100', async () => {
+      const str = makeString(100);
+      await tests.helpers.httpCallAsserter(generateCall(str));
+      await tests.helpers.countEnvironmentLogsEntries(2);
+      await tests.helpers.requestLogBodyContains('BODY HAS BEEN TRUNCATED');
+    });
+
+    it('Set size to 1000', async () => {
+      await tests.helpers.openSettingsModal();
+      await tests.spectron.client.element(inputBodySize).setValue('1000');
+      await tests.helpers.closeSettingsModal();
+    });
+
+    it('The size is 1000, do not truncate on 999', async () => {
+      const str = makeString(999);
+      await tests.helpers.httpCallAsserter(generateCall(str));
+      await tests.helpers.countEnvironmentLogsEntries(3);
+      await tests.helpers.requestLogBodyContains(str);
+    });
+
+    it('The default size is 1000, do truncate on 1000', async () => {
+      const str = makeString(1000);
+      await tests.helpers.httpCallAsserter(generateCall(str));
+      await tests.helpers.countEnvironmentLogsEntries(4);
+      await tests.helpers.requestLogBodyContains('BODY HAS BEEN TRUNCATED');
+    });
+  });
+
+});


### PR DESCRIPTION
**Description**

Implements a variable log body size. On the Settings modal we can setting the value for truncate the log's request and response body. The default value is 10000.

**Related Issue**

Issue #186 

**How Has This Been Tested?**

I enabled the proxy to a mirror api and send large random text. Next I change the variable value and made the request again.

**Screenshots (if appropriate):**

![image](https://user-images.githubusercontent.com/6676601/67912862-fe69df80-fb69-11e9-94ab-76702593af0a.png)

**Closing issues**

Closes #186 
