### PR TITLE
Add AUR download hint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Feel free to test it and give some feedback!
 
 ## Download
 
-You can get Mockoon [latest release](https://github.com/mockoon/mockoon/releases/latest) directly from this repository or on the official [website](https://mockoon.com/#download). Mockoon is also available through Homebrew `brew cask install mockoon`, Snap store `snap install mockoon` or Chocolatey `choco install mockoon`.
+You can get Mockoon [latest release](https://github.com/mockoon/mockoon/releases/latest) directly from this repository or on the official [website](https://mockoon.com/#download). Mockoon is also available through Homebrew `brew cask install mockoon`, Snap store `snap install mockoon`, Chocolatey `choco install mockoon` or AUR `yay -S mockoon-bin` (or any other AUR helper).
 
 ## Give feedback
 


### PR DESCRIPTION
**Description**

This PR simply adds a hint to the Download section in the README.md that the package is now also available through the arch user repository.

**Motivation and Context**

Since I neither wanted to use the snap version of Mockoon, nor manually download and install the .deb file, I created a `PKGBUILD` and pushed it to the AUR (https://aur.archlinux.org/packages/mockoon-bin/).

**How Has This Been Tested?**

Execute `yay -S mockoon-bin` (or use any other AUR helper instead of yay) on your Arch Linux machine. The debian file is automatically fetched from github and installed.
