### PR TITLE
Add arch linux container to bump AUR package version

### DIFF
--- a/scripts/aur-version-bump/Dockerfile
+++ b/scripts/aur-version-bump/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:experimental
+FROM archlinux
+
+RUN pacman -Syu --noconfirm
+RUN pacman -S git openssh base-devel sudo --noconfirm
+
+RUN useradd -m -d /build -s /bin/bash build-user
+ADD sudoers /etc/sudoers
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+
+RUN mkdir -m 700 /root/.ssh; \
+  touch -m 600 /root/.ssh/known_hosts; \
+  ssh-keyscan github.com aur.archlinux.org > /root/.ssh/known_hosts
+
+RUN git config --global user.email "hi@255kb.com"
+RUN git config --global user.name "Guillaume Monnet"
+
+RUN --mount=type=ssh,id=default git clone ssh://aur@aur.archlinux.org/mockoon-bin.git /repo
+
+RUN chown build-user /repo
+
+COPY bump /usr/local/bin/
+
+ENTRYPOINT [ "/usr/local/bin/bump" ]
+
+CMD ["0.0.1"]

--- a/scripts/aur-version-bump/README.md
+++ b/scripts/aur-version-bump/README.md
@@ -1,0 +1,10 @@
+# Preparation:
+Set the git configuration to your git email and name in der Dockerfile (line 15,16).
+
+# Build:
+`DOCKER_BUILDKIT=1 docker image build --ssh default -t mockoon-bin-version-bump .`
+
+If you want to use another ssh key than default you have to pass its value.
+
+# Run:
+`docker run --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent mockoon-bin-version-bump "<VERSION>"`

--- a/scripts/aur-version-bump/bump
+++ b/scripts/aur-version-bump/bump
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd /repo
+echo "Pulling repo"
+git pull
+
+echo "Setting pkgver to $1"
+sed -i "/pkgver=/c\pkgver=$1" PKGBUILD
+
+echo "Downloading debian package (https://github.com/mockoon/mockoon/releases/download/v$1/mockoon-$1.deb) for md5sum"
+md5sum=`curl -sL "https://github.com/mockoon/mockoon/releases/download/v$1/mockoon-$1.deb" | md5sum | cut -d ' ' -f 1`
+
+echo "Setting md5sums to $md5sum"
+sed -i "/md5sums=/c\md5sums=('$md5sum')" PKGBUILD
+
+echo "Generating .SRCINFO"
+sudo -u build-user makepkg --printsrcinfo > .SRCINFO
+
+echo "Committing and pushing"
+git add .
+git commit -m "Bump version to $1"
+git push

--- a/scripts/aur-version-bump/sudoers
+++ b/scripts/aur-version-bump/sudoers
@@ -1,0 +1,2 @@
+root ALL=(ALL) ALL
+build-user ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
**Description**
Since you had trouble making version updates to the AUR PKGBUILD which I added, I figured I could provide an Arch Linux container with a small script that does just that.

**Motivation and Context**
Well, using this, it shouldn't be necessary anymore to contact me to bump the version number of the AUR package ;)

**How Has This Been Tested?**
Follow the steps provided in the README.md to build and run the container. To see if it's working, you can simply use the current version "1.7.0" as parameter to the docker run command - git should then output that there have been no changes.

**Screenshots (if appropriate):**
![image](https://user-images.githubusercontent.com/35728419/71547500-def00700-29a0-11ea-89e9-5790944e2ad9.png)


Happy Holidays,
Lukas