### PR TITLE
Fix/issue-136: Always return environment headers in responses

### DIFF
--- a/src/app/services/server.service.ts
+++ b/src/app/services/server.service.ts
@@ -71,6 +71,7 @@ export class ServerService {
 
     // apply latency, cors, routes and proxy to express server
     this.logRequests(server, environment);
+    this.setCustomHeaders(server, environment);
     this.logResponses(server, environment);
     this.setEnvironmentLatency(server, environment.uuid);
     this.setRoutes(server, environment);
@@ -346,6 +347,23 @@ export class ServerService {
       const enhancedReq = req as IEnhancedRequest;
       enhancedReq.uuid = log.uuid;
       this.store.update(logRequestAction(environment.uuid, log));
+      next();
+    });
+  }
+
+  /**
+   * Ensure that environment headers are always set in responses
+   *
+   * @param server - the server serving responses 
+   * @param environment - the environment where the headers are configured
+   */
+  private setCustomHeaders(server: any, environment: Environment) {
+    server.use((req, res, next) => {
+      for (const header of environment.headers) {
+        if (!res.hasHeader(header.key)) {
+          res.setHeader(header.key, header.value);
+        }
+      }
       next();
     });
   }


### PR DESCRIPTION
**Description**
This PR ensures that  headers defined in proxy mode are always returned in responses.

**Related Issue**

https://github.com/mockoon/mockoon/issues/136


**Motivation and Context**
In my projects, I often use custom headers like `x-auth-key` for authentication. If you use Mockoon with this header (x-auth-key) set in an environment, it will work if the proxied server returns a  200 response.  Incase of a 404 error from the proxied server, the header `x-auth-key` is ignored. See https://github.com/mockoon/mockoon/issues/136

**How Has This Been Tested?**

* Use Mockoon in proxy mode with some headers defined. 
* Access some valid endpoints in the proxied server from your browser and inspect  the response headers. It should return the headers defined
* Access an endpoint that does not exist in the proxied server such that you get a 404 error.  The headers you defined in mockoon should be returned in the response as well.


** Unit/UI test?**
No, this is my entry PR to this project. Things are still sketchy for me.
