### PR TITLE
Fix environment log hidden icon - #238

### DIFF
--- a/src/app/components/environment-logs.component.html
+++ b/src/app/components/environment-logs.component.html
@@ -13,20 +13,22 @@
                     <span class="badge badge-default ml-0 mr-3 http-method-{{log.method | lowercase}} route-method">{{log.method | uppercase}}</span>
                   </div>
                   <div class="ellipsis route">{{log.url}}</div>
-                  <div>
-                    <button type="button" class="btn btn-link btn-icon btn-mock" (click)="createRouteFromLog(log.uuid)">
-                      <i class="material-icons" ngbTooltip="Mock">control_point_duplicate</i>
-                    </button>
-                  </div>
-                  <div>
-                    <span *ngIf="log.route" class="float-right text-success">
-                      <i class="material-icons" ngbTooltip="Request caught">check</i>
-                    </span>
-                  </div>
-                  <div>
-                    <span *ngIf="!log.route && log.proxied" class="float-right text-primary">
-                      <i class="material-icons" ngbTooltip="Request proxied">security</i>
-                    </span>
+                  <div class="ml-auto pl-1 d-flex flex-row">
+                    <div>
+                      <button type="button" class="btn btn-link btn-icon btn-mock" (click)="createRouteFromLog(log.uuid)">
+                        <i class="material-icons" ngbTooltip="Mock">control_point_duplicate</i>
+                      </button>
+                    </div>
+                    <div>
+                      <span *ngIf="log.route" class="float-right text-success">
+                        <i class="material-icons" ngbTooltip="Request caught">check</i>
+                      </span>
+                    </div>
+                    <div>
+                      <span *ngIf="!log.route && log.proxied" class="float-right text-primary">
+                        <i class="material-icons" ngbTooltip="Request proxied">security</i>
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <div class="menu-subtitle ellipsis">

--- a/src/app/components/environment-logs.component.html
+++ b/src/app/components/environment-logs.component.html
@@ -8,13 +8,11 @@
             <a class="nav-link" [ngClass]="{'active': logIndex === (selectedLogIndex$ | async)}"
               (click)="showLogDetails(logIndex)">
               <div class="d-flex flex-column">
-                <div class="d-flex flex-row">
-                  <div class="d-flex flex-row w-100 route">
-                    <div>
-                      <span class="badge badge-default ml-0 mr-3 http-method-{{log.method | lowercase}}">{{log.method | uppercase}}</span>
-                    </div>
-                    <div class="ellipsis">{{log.url}}</div>
+                <div class="d-flex flex-row ">
+                  <div>
+                    <span class="badge badge-default ml-0 mr-3 http-method-{{log.method | lowercase}} route-method">{{log.method | uppercase}}</span>
                   </div>
+                  <div class="ellipsis route">{{log.url}}</div>
                   <div>
                     <button type="button" class="btn btn-link btn-icon btn-mock" (click)="createRouteFromLog(log.uuid)">
                       <i class="material-icons" ngbTooltip="Mock">control_point_duplicate</i>

--- a/test/environment-logs.spec.ts
+++ b/test/environment-logs.spec.ts
@@ -45,12 +45,14 @@ describe('Environment logs', () => {
   });
 
   it('First entry is GET /test and was not caught by the application', async () => {
-    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route`).should.eventually.equal('GET\n/test');
+    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route-method`).should.eventually.equal('GET');
+    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route`).should.eventually.equal('/test');
     await tests.app.client.waitForExist(`${environmentLogsItemSelector}:nth-child(1) .nav-link i[ngbTooltip="Request caught"]`, 5000, true);
   });
 
   it('Second entry is GET /answer and was caught by the application', async () => {
-    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(2) .nav-link .route`).should.eventually.equal('GET\n/answer');
+    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(2) .nav-link .route-method`).should.eventually.equal('GET');
+    await tests.app.client.getText(`${environmentLogsItemSelector}:nth-child(2) .nav-link .route`).should.eventually.equal('/answer');
     await tests.app.client.waitForExist(`${environmentLogsItemSelector}:nth-child(2) .nav-link i[ngbTooltip="Request caught"]`);
   });
 

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -36,8 +36,11 @@ describe('Proxy', () => {
 
   it('First entry is GET /answer and was proxied by the application', async () => {
     await tests.app.client
+      .getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route-method`)
+      .should.eventually.equal('GET');
+    await tests.app.client
       .getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route`)
-      .should.eventually.equal('GET\n/answer');
+      .should.eventually.equal('/answer');
     await tests.app.client.waitForExist(
       `${environmentLogsItemSelector}:nth-child(1) .nav-link i[ngbTooltip="Request proxied"]`,
       5000,
@@ -83,8 +86,11 @@ describe('Proxy', () => {
     await tests.helpers.switchViewInHeader('ENV_LOGS');
     await tests.helpers.countEnvironmentLogsEntries(2);
     await tests.app.client
+      .getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route-method`)
+      .should.eventually.equal('GET');
+    await tests.app.client
       .getText(`${environmentLogsItemSelector}:nth-child(1) .nav-link .route`)
-      .should.eventually.equal('GET\n/answer');
+      .should.eventually.equal('/answer');
     await tests.app.client.waitForExist(
       `${environmentLogsItemSelector}:nth-child(1) .nav-link i[ngbTooltip="Request proxied"]`,
       5000,


### PR DESCRIPTION
<!-- 
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
 -->

**Description**
Fixed css in order not to hide environment log entries icon.
<!-- Describe your changes in detail -->

**Related Issue**

<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->
Issue #238 


**Motivation and Context**

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

**How Has This Been Tested?**

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1. Start the server 
2. Make a req
`curl    http://localhost:3000/bigtest/api/v1/refreshwidget/bigonee`
3. Add the route 
4. Make again a req
`curl    http://localhost:3000/bigtest/api/v1/refreshwidget/bigonee`

Check the environment logs 


**Screenshots (if appropriate):**
![image](https://user-images.githubusercontent.com/1183265/75628492-259cf000-5be2-11ea-9018-333396aaa8e4.png)

**Closing issues**
Closes #238 
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
