### PR TITLE
Add null check for swagger v2 host field when importing

### DIFF
--- a/src/app/services/openapi-converter.service.ts
+++ b/src/app/services/openapi-converter.service.ts
@@ -100,7 +100,7 @@ export class OpenAPIConverterService {
     );
 
     // parse the port
-    newEnvironment.port =
+    newEnvironment.port = parsedAPI.host &&
       parseInt(parsedAPI.host.split(':')[1], 10) || newEnvironment.port;
 
     if (parsedAPI.basePath) {


### PR DESCRIPTION
**Description**

Added a null check for the host field when importing a swagger v2 file. As the types correctly indicate, the host field is optional, it wasn't treated this way however.

Two side notes:
- Optional chaining would have been preferred, however the current angular compiler version doesn't allow a recent enough TypeScript version, which brings the feature (>= 3.7).
- These sort of bugs are preventable with the TypeScript compiler option `strict: true`. Not sure if it's left out intentionally, however when enabling it locally, it showed up quite some more type errors.

**Related Issue**

https://github.com/mockoon/mockoon/issues/326

**How Has This Been Tested?**
Import the swagger v2 file (or any other one without the `host` field) from the linked issue: it should work using the default port.

**Closing issues**

closes #326 
