### PR TITLE
Generate random ObjectId for mocking mongodb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -649,6 +649,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -4711,6 +4712,16 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -5075,6 +5086,11 @@
         "node-releases": "^1.1.52",
         "pkg-up": "^3.1.0"
       }
+    },
+    "bson-objectid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.3.1.tgz",
+      "integrity": "sha512-eQBNQXsisEAXlwiSy8zRNZdW2xDBJaEVkTPbodYR9hGxxtE548Qq7ilYOd8WAQ86xF7NRUdiWSQ1pa/TkKiE2A=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -8321,6 +8337,13 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.0.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -15973,6 +15996,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -16703,6 +16727,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "brace": "0.11.1",
+    "bson-objectid": "1.3.1",
     "electron-is-dev": "1.1.0",
     "electron-json-storage": "4.2.0",
     "electron-log": "4.1.0",

--- a/src/app/libs/template-parser.lib.ts
+++ b/src/app/libs/template-parser.lib.ts
@@ -266,6 +266,13 @@ const TemplateParserHelpers = function (request: Request) {
     newline: function () {
       return '\n';
     },
+    // returns a new random ObjectId compatible with MongoDB
+    objectId: function() {
+      var timestamp = (new Date().getTime() / 1000 | 0).toString(16);
+      return timestamp + 'xxxxxxxxxxxxxxxx'.replace(/[x]/g, function() {
+          return (Math.random() * 16 | 0).toString(16);
+      }).toLowerCase();
+    },
     // Handlebars hook when a helper is missing
     helperMissing: function () {
       return '';

--- a/src/app/libs/template-parser.lib.ts
+++ b/src/app/libs/template-parser.lib.ts
@@ -7,6 +7,7 @@ import { get as objectGet } from 'object-path';
 import { Logger } from 'src/app/classes/logger';
 import { OldTemplatingHelpers } from 'src/app/libs/old-templating-helpers';
 import { IsEmpty } from 'src/app/libs/utils.lib';
+import ObjectId from 'bson-objectid';
 
 const logger = new Logger('[LIB][TEMPLATE-PARSER]');
 
@@ -266,12 +267,15 @@ const TemplateParserHelpers = function (request: Request) {
     newline: function () {
       return '\n';
     },
-    // returns a new random ObjectId compatible with MongoDB
-    objectId: function() {
-      var timestamp = (new Date().getTime() / 1000 | 0).toString(16);
-      return timestamp + 'xxxxxxxxxxxxxxxx'.replace(/[x]/g, function() {
-          return (Math.random() * 16 | 0).toString(16);
-      }).toLowerCase();
+    // returns a compatible ObjectId
+    // * if value is undefined or null returns a random ObjectId
+    // * if value is defined is used a seed, can be a string, number or Buffer
+    objectId: function(defaultValue: string) {
+      if (typeof defaultValue === 'object') {
+        defaultValue = undefined;
+      }
+
+      return new ObjectId(defaultValue).toHexString();
     },
     // Handlebars hook when a helper is missing
     helperMissing: function () {

--- a/test/data/templating/environments.json
+++ b/test/data/templating/environments.json
@@ -1092,6 +1092,60 @@
         ]
       },
       {
+        "uuid": "921c9906-ea2b-42fa-abe2-55f21200ad2e",
+        "method": "get",
+        "endpoint": "objectid_1",
+        "documentation": "",
+        "enabled": true,
+        "responses": [
+          {
+            "uuid": "67d9190b-7312-4ad4-b8d4-c1cc7d66807c",
+            "body": "{{objectId}}",
+            "latency": 0,
+            "statusCode": 200,
+            "label": "",
+            "headers": [
+              {
+                "key": "Content-Type",
+                "value": "text/plain"
+              }
+            ],
+            "filePath": "",
+            "sendFileAsBody": false,
+            "disableTemplating": false,
+            "rules": [],
+            "rulesOperator": "OR"
+          }
+        ]
+      },
+      {
+        "uuid": "13839664-6752-482d-8ce2-fc7ae301dc11",
+        "method": "get",
+        "endpoint": "objectid_2",
+        "documentation": "",
+        "enabled": true,
+        "responses": [
+          {
+            "uuid": "2451572c-d838-4f55-94c8-c615942efea8",
+            "body": "{{objectId '54495ad94c934721ede76d90'}}",
+            "latency": 0,
+            "statusCode": 200,
+            "label": "",
+            "headers": [
+              {
+                "key": "Content-Type",
+                "value": "text/plain"
+              }
+            ],
+            "filePath": "",
+            "sendFileAsBody": false,
+            "disableTemplating": false,
+            "rules": [],
+            "rulesOperator": "OR"
+          }
+        ]
+      },
+      {
         "uuid": "51993754-4d1d-4723-902f-c3ebc8c86e24",
         "method": "get",
         "endpoint": "base64",

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -362,6 +362,11 @@ export class Helpers {
           });
         } else if (
           propertyName === 'body' &&
+          httpCall.testedResponse.body instanceof RegExp
+        ) {
+          expect(response.body).to.match(httpCall.testedResponse.body)
+        } else if (
+          propertyName === 'body' &&
           typeof httpCall.testedResponse.body === 'object'
         ) {
           expect(response.body).to.have.string(

--- a/test/lib/models.ts
+++ b/test/lib/models.ts
@@ -1,5 +1,5 @@
 export type HttpCallResponse = {
-  body?: string | { contains: string };
+  body?: string | { contains: string } | RegExp;
   status?: number;
   headers?: {
     [key in string]: string | string[];

--- a/test/suites/templating.spec.ts
+++ b/test/suites/templating.spec.ts
@@ -748,6 +748,24 @@ const testSuites: { name: string; tests: HttpCall[] }[] = [
         }
       },
       {
+        description: 'Helper: random objectId',
+        path: '/objectid_1',
+        method: 'GET',
+        testedResponse: {
+          status: 200,
+          body: /^(?=[a-f\d]{24}$)(\d+[a-f]|[a-f]+\d)/i
+        }
+      },
+      {
+        description: 'Helper: objectId based on time',
+        path: '/objectid_2',
+        method: 'GET',
+        testedResponse: {
+          status: 200,
+          body: '54495ad94c934721ede76d90'
+        }
+      },
+      {
         description: 'Helper: base64 (inline + block helper)',
         path: '/base64',
         method: 'GET',


### PR DESCRIPTION
**Description**

{{objectId}} will generate a random MongoDB's ObjectId in the format of: 5f7c1ee149354fbcb2f9189b

**Related Issue**

Closes #342 

**Motivation and Context**

We use ObjectId as id and we expose them on our REST APIs
