### PR TITLE
Add route headers and rules count in tab

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -303,8 +303,8 @@
                         (click)="setActiveTab('HEADERS')">Headers</a>
                       </li>
                       <li class="nav-item">
-                        <a class="nav-link" [ngClass]="{'active': activeTab === 'RULES'}"
-                          (click)="setActiveTab('RULES')">Rules</a>
+                        <a class="nav-link" data-testid="rules-tab" [ngClass]="{'active': activeTab === 'RULES'}"
+                          (click)="setActiveTab('RULES')">Rules{{activeRouteResponseRulesLabelSuffix$ | async}}</a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" [ngClass]="{'active': activeTab === 'SETTINGS'}"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -300,11 +300,11 @@
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" data-testid="headers-tab" [ngClass]="{'active': activeTab === 'HEADERS'}"
-                        (click)="setActiveTab('HEADERS')">Headers{{activeRouteResponseHeadersLabelSuffix$ | async}}</a>
+                        (click)="setActiveTab('HEADERS')">Headers{{(activeRouteResponseHeaderCount$ | async) > 0 ? ' (' + (activeRouteResponseHeaderCount$ | async)+')' : ''}}</a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" data-testid="rules-tab" [ngClass]="{'active': activeTab === 'RULES'}"
-                          (click)="setActiveTab('RULES')">Rules{{activeRouteResponseRulesLabelSuffix$ | async}}</a>
+                          (click)="setActiveTab('RULES')">Rules{{(activeRouteResponseRuleCount$ | async) > 0 ? ' (' + (activeRouteResponseRuleCount$ | async)+')' : ''}}</a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" [ngClass]="{'active': activeTab === 'SETTINGS'}"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -299,11 +299,11 @@
                         (click)="setActiveTab('RESPONSE')">Status & Body</a>
                       </li>
                       <li class="nav-item">
-                        <a class="nav-link" data-testid="headers-tab" [ngClass]="{'active': activeTab === 'HEADERS'}"
+                        <a class="nav-link" [ngClass]="{'active': activeTab === 'HEADERS'}"
                         (click)="setActiveTab('HEADERS')">Headers{{(activeRouteResponseHeaderCount$ | async) > 0 ? ' (' + (activeRouteResponseHeaderCount$ | async)+')' : ''}}</a>
                       </li>
                       <li class="nav-item">
-                        <a class="nav-link" data-testid="rules-tab" [ngClass]="{'active': activeTab === 'RULES'}"
+                        <a class="nav-link" [ngClass]="{'active': activeTab === 'RULES'}"
                           (click)="setActiveTab('RULES')">Rules{{(activeRouteResponseRuleCount$ | async) > 0 ? ' (' + (activeRouteResponseRuleCount$ | async)+')' : ''}}</a>
                       </li>
                       <li class="nav-item">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -300,11 +300,21 @@
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" [ngClass]="{'active': activeTab === 'HEADERS'}"
-                        (click)="setActiveTab('HEADERS')">Headers{{(activeRouteResponseHeaderCount$ | async) > 0 ? ' (' + (activeRouteResponseHeaderCount$ | async)+')' : ''}}</a>
+                           (click)="setActiveTab('HEADERS')">
+                          Headers
+                          <ng-container *ngIf="activeRouteResponseHeaderCount$ | async as activeRouteResponseHeaderCount">
+                            ({{activeRouteResponseHeaderCount}})
+                          </ng-container>
+                        </a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" [ngClass]="{'active': activeTab === 'RULES'}"
-                          (click)="setActiveTab('RULES')">Rules{{(activeRouteResponseRuleCount$ | async) > 0 ? ' (' + (activeRouteResponseRuleCount$ | async)+')' : ''}}</a>
+                           (click)="setActiveTab('RULES')">
+                          Rules
+                          <ng-container *ngIf="activeRouteResponseRuleCount$ | async as activeRouteResponseRuleCount">
+                            ({{activeRouteResponseRuleCount}})
+                          </ng-container>
+                        </a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" [ngClass]="{'active': activeTab === 'SETTINGS'}"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -299,8 +299,8 @@
                         (click)="setActiveTab('RESPONSE')">Status & Body</a>
                       </li>
                       <li class="nav-item">
-                        <a class="nav-link" [ngClass]="{'active': activeTab === 'HEADERS'}"
-                        (click)="setActiveTab('HEADERS')">Headers</a>
+                        <a class="nav-link" data-testid="headers-tab" [ngClass]="{'active': activeTab === 'HEADERS'}"
+                        (click)="setActiveTab('HEADERS')">Headers{{activeRouteResponseHeadersLabelSuffix$ | async}}</a>
                       </li>
                       <li class="nav-item">
                         <a class="nav-link" data-testid="rules-tab" [ngClass]="{'active': activeTab === 'RULES'}"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -91,6 +91,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   public activeRouteResponseForm: FormGroup;
   public activeRouteResponseIndex$: Observable<number>;
   public activeRouteResponseLastLog$: Observable<EnvironmentLog>;
+  public activeRouteResponseRulesLabelSuffix$: Observable<string>;
   public injectedHeaders$: Observable<Header[]>;
   public activeTab$: Observable<TabsNameType>;
   public activeView$: Observable<ViewsNameType>;
@@ -197,6 +198,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.environmentsLogs$ = this.store.select('environmentsLogs');
     this.activeRouteResponseLastLog$ = this.store.selectActiveRouteResponseLastLog();
     this.toasts$ = this.store.select('toasts');
+
+    this.activeRouteResponseRulesLabelSuffix$ = this.selectActiveRouteResponseRulesLabelSuffix();
 
     this.initFormValues();
   }
@@ -649,5 +652,11 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   private toggleRoute(routeUUID?: string) {
     this.environmentsService.toggleRoute(routeUUID);
+  }
+
+  private selectActiveRouteResponseRulesLabelSuffix() {
+    return this.store
+      .selectActiveRouteResponseRuleCount()
+      .pipe(map((ruleCount) => (ruleCount > 0 ? ` (${ruleCount})` : '')));
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -91,8 +91,8 @@ export class AppComponent implements OnInit, AfterViewInit {
   public activeRouteResponseForm: FormGroup;
   public activeRouteResponseIndex$: Observable<number>;
   public activeRouteResponseLastLog$: Observable<EnvironmentLog>;
-  public activeRouteResponseHeadersLabelSuffix$: Observable<string>;
-  public activeRouteResponseRulesLabelSuffix$: Observable<string>;
+  public activeRouteResponseHeaderCount$: Observable<number>;
+  public activeRouteResponseRuleCount$: Observable<number>;
   public injectedHeaders$: Observable<Header[]>;
   public activeTab$: Observable<TabsNameType>;
   public activeView$: Observable<ViewsNameType>;
@@ -189,6 +189,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.activeRoute$ = this.store.selectActiveRoute();
     this.activeRouteResponse$ = this.store.selectActiveRouteResponse();
     this.activeRouteResponseIndex$ = this.store.selectActiveRouteResponseIndex();
+    this.activeRouteResponseHeaderCount$ = this.store.selectActiveRouteResponseHeaderCount();
+    this.activeRouteResponseRuleCount$ = this.store.selectActiveRouteResponseRuleCount();
     this.activeTab$ = this.store.select('activeTab');
     this.activeView$ = this.store.select('activeView');
     this.activeEnvironmentState$ = this.store.selectActiveEnvironmentStatus();
@@ -199,9 +201,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.environmentsLogs$ = this.store.select('environmentsLogs');
     this.activeRouteResponseLastLog$ = this.store.selectActiveRouteResponseLastLog();
     this.toasts$ = this.store.select('toasts');
-
-    this.activeRouteResponseHeadersLabelSuffix$ = this.selectActiveRouteResponseHeadersLabelSuffix();
-    this.activeRouteResponseRulesLabelSuffix$ = this.selectActiveRouteResponseRulesLabelSuffix();
 
     this.initFormValues();
   }
@@ -654,17 +653,5 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   private toggleRoute(routeUUID?: string) {
     this.environmentsService.toggleRoute(routeUUID);
-  }
-
-  private selectActiveRouteResponseHeadersLabelSuffix() {
-    return this.store
-      .selectActiveRouteResponseHeaderCount()
-      .pipe(map((ruleCount) => (ruleCount > 0 ? ` (${ruleCount})` : '')));
-  }
-
-  private selectActiveRouteResponseRulesLabelSuffix() {
-    return this.store
-      .selectActiveRouteResponseRuleCount()
-      .pipe(map((ruleCount) => (ruleCount > 0 ? ` (${ruleCount})` : '')));
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -91,6 +91,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   public activeRouteResponseForm: FormGroup;
   public activeRouteResponseIndex$: Observable<number>;
   public activeRouteResponseLastLog$: Observable<EnvironmentLog>;
+  public activeRouteResponseHeadersLabelSuffix$: Observable<string>;
   public activeRouteResponseRulesLabelSuffix$: Observable<string>;
   public injectedHeaders$: Observable<Header[]>;
   public activeTab$: Observable<TabsNameType>;
@@ -199,6 +200,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.activeRouteResponseLastLog$ = this.store.selectActiveRouteResponseLastLog();
     this.toasts$ = this.store.select('toasts');
 
+    this.activeRouteResponseHeadersLabelSuffix$ = this.selectActiveRouteResponseHeadersLabelSuffix();
     this.activeRouteResponseRulesLabelSuffix$ = this.selectActiveRouteResponseRulesLabelSuffix();
 
     this.initFormValues();
@@ -652,6 +654,12 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   private toggleRoute(routeUUID?: string) {
     this.environmentsService.toggleRoute(routeUUID);
+  }
+
+  private selectActiveRouteResponseHeadersLabelSuffix() {
+    return this.store
+      .selectActiveRouteResponseHeaderCount()
+      .pipe(map((ruleCount) => (ruleCount > 0 ? ` (${ruleCount})` : '')));
   }
 
   private selectActiveRouteResponseRulesLabelSuffix() {

--- a/src/app/services/schemas-builder.service.ts
+++ b/src/app/services/schemas-builder.service.ts
@@ -25,7 +25,7 @@ export class SchemasBuilderService {
       latency: 0,
       statusCode: 200,
       label: '',
-      headers: [this.buildHeader()],
+      headers: [],
       filePath: '',
       sendFileAsBody: false,
       rules: [],

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -258,6 +258,15 @@ export class Store {
   }
 
   /**
+   * Select active route rule count observable
+   */
+  public selectActiveRouteResponseRuleCount(): Observable<number> {
+    return this.selectActiveRouteResponseProperty('rules').pipe(
+      map((rules) => rules.length)
+    );
+  }
+
+  /**
    * Get environment by uuid
    */
   public getEnvironmentByUUID(UUID: string): Environment {

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -258,6 +258,15 @@ export class Store {
   }
 
   /**
+   * Select active route header count observable
+   */
+  public selectActiveRouteResponseHeaderCount(): Observable<number> {
+    return this.selectActiveRouteResponseProperty('headers').pipe(
+      map((headers) => headers.length)
+    );
+  }
+
+  /**
    * Select active route rule count observable
    */
   public selectActiveRouteResponseRuleCount(): Observable<number> {

--- a/test/suites/ui-interactions.spec.ts
+++ b/test/suites/ui-interactions.spec.ts
@@ -127,4 +127,62 @@ describe('UI interactions', () => {
       });
     });
   });
+
+  describe('Headers && Rules tabs', () => {
+    const tests = new Tests('ui');
+
+    it('Rules tab shows count of active rules', async () => {
+      const rulesTabSelector =
+        '#route-responses-menu .nav.nav-tabs [data-testid="rules-tab"]';
+
+      let text = await tests.helpers.getElementText(rulesTabSelector);
+      expect(text).to.equal('Rules');
+
+      await tests.helpers.switchTab('RULES');
+      await tests.helpers.addResponseRule({
+        modifier: 'var',
+        target: 'params',
+        value: '10',
+        isRegex: false
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(rulesTabSelector);
+      expect(text).to.equal('Rules (1)');
+
+      await tests.helpers.addResponseRule({
+        modifier: 'test',
+        target: 'query',
+        value: 'true',
+        isRegex: false
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(rulesTabSelector);
+      expect(text).to.equal('Rules (2)');
+
+      await tests.helpers.addRouteResponse();
+      await tests.helpers.countRouteResponses(2);
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(rulesTabSelector);
+      expect(text).to.equal('Rules');
+
+      await tests.helpers.switchTab('RULES');
+      await tests.helpers.addResponseRule({
+        modifier: 'var',
+        target: 'params',
+        value: '10',
+        isRegex: false
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(rulesTabSelector);
+      expect(text).to.equal('Rules (1)');
+    });
+  });
 });

--- a/test/suites/ui-interactions.spec.ts
+++ b/test/suites/ui-interactions.spec.ts
@@ -165,7 +165,7 @@ describe('UI interactions', () => {
       // this is needed for the tab re-render to complete
       await tests.app.client.pause(100);
       text = await tests.helpers.getElementText(headersTabSelector);
-      expect(text).to.equal('Headers (1)');
+      expect(text).to.equal('Headers');
 
       await tests.helpers.switchTab('HEADERS');
       await tests.helpers.addHeader('route-response-headers', {
@@ -176,7 +176,7 @@ describe('UI interactions', () => {
       // this is needed for the tab re-render to complete
       await tests.app.client.pause(100);
       text = await tests.helpers.getElementText(headersTabSelector);
-      expect(text).to.equal('Headers (2)');
+      expect(text).to.equal('Headers (1)');
     });
 
     it('Rules tab shows the rule count', async () => {

--- a/test/suites/ui-interactions.spec.ts
+++ b/test/suites/ui-interactions.spec.ts
@@ -131,7 +131,55 @@ describe('UI interactions', () => {
   describe('Headers && Rules tabs', () => {
     const tests = new Tests('ui');
 
-    it('Rules tab shows count of active rules', async () => {
+    it('Headers tab shows the header count', async () => {
+      const headersTabSelector =
+        '#route-responses-menu .nav.nav-tabs [data-testid="headers-tab"]';
+
+      let text = await tests.helpers.getElementText(headersTabSelector);
+      expect(text).to.equal('Headers (1)');
+
+      await tests.helpers.switchTab('HEADERS');
+      await tests.helpers.addHeader('route-response-headers', {
+        key: 'route-header',
+        value: 'route-header'
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(headersTabSelector);
+      expect(text).to.equal('Headers (2)');
+
+      await tests.helpers.addHeader('route-response-headers', {
+        key: 'route-header-2',
+        value: 'route-header-2'
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(headersTabSelector);
+      expect(text).to.equal('Headers (3)');
+
+      await tests.helpers.addRouteResponse();
+      await tests.helpers.countRouteResponses(2);
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(headersTabSelector);
+      expect(text).to.equal('Headers (1)');
+
+      await tests.helpers.switchTab('HEADERS');
+      await tests.helpers.addHeader('route-response-headers', {
+        key: 'route-header-3',
+        value: 'route-header-3'
+      });
+
+      // this is needed for the tab re-render to complete
+      await tests.app.client.pause(100);
+      text = await tests.helpers.getElementText(headersTabSelector);
+      expect(text).to.equal('Headers (2)');
+    });
+
+    it('Rules tab shows the rule count', async () => {
       const rulesTabSelector =
         '#route-responses-menu .nav.nav-tabs [data-testid="rules-tab"]';
 
@@ -164,7 +212,7 @@ describe('UI interactions', () => {
       expect(text).to.equal('Rules (2)');
 
       await tests.helpers.addRouteResponse();
-      await tests.helpers.countRouteResponses(2);
+      await tests.helpers.countRouteResponses(3);
 
       // this is needed for the tab re-render to complete
       await tests.app.client.pause(100);

--- a/test/suites/ui-interactions.spec.ts
+++ b/test/suites/ui-interactions.spec.ts
@@ -133,7 +133,7 @@ describe('UI interactions', () => {
 
     it('Headers tab shows the header count', async () => {
       const headersTabSelector =
-        '#route-responses-menu .nav.nav-tabs [data-testid="headers-tab"]';
+        '#route-responses-menu .nav.nav-tabs .nav-item:nth-child(2)';
 
       let text = await tests.helpers.getElementText(headersTabSelector);
       expect(text).to.equal('Headers (1)');
@@ -181,7 +181,7 @@ describe('UI interactions', () => {
 
     it('Rules tab shows the rule count', async () => {
       const rulesTabSelector =
-        '#route-responses-menu .nav.nav-tabs [data-testid="rules-tab"]';
+        '#route-responses-menu .nav.nav-tabs .nav-item:nth-child(3)';
 
       let text = await tests.helpers.getElementText(rulesTabSelector);
       expect(text).to.equal('Rules');


### PR DESCRIPTION
**Parent issue** 

Closes #299

**Some details prior to the technical ones**
Since this is a small, contained feature, I took the initiative and implemented it without bugging you before doing the work.
However, if you don't like the implementation, I'll apply any change requests you make.

I also took the initiative to create the following behavior:
- When there are no headers, or no rules, the respective tab label does not contain any number indication. (So it is _Headers_ and _Rules_.)
- When one of the two tabs contains more-than-zero items, its label starts containing the count. (Examples: _Headers (1)_, _Rules (7)_ etc.)

**Technical implementation details**

- 2 methods are added in `src/app/app.component.ts` that calculate the suffixes for the tab labels. I wanted to follow the naming conventions that already exist there (e.g. `activeRouteResponseLastLog$`), so I ended up with these two names: `activeRouteResponseRulesLabelSuffix$` and `activeRouteResponseHeadersLabelSuffix$` (because we are talking about the suffix of the label -- all the aforementioned conditional logic is in there).
- I noticed that, in a fresh environment/route/response, the _Headers_ tab **always** contains an empty header, while the _Rules_ tab contains zero rules. This leads to an inconsistency where the _Headers_ tab always starts with the label _Headers (1)_, while the _Rules_ tab starts as plain _Rules_. This is a conceptual bug to me, as the _Headers_ tab is essentially empty. We either have to filter out empty headers while making the count, or start the tab with no header pre-created. Either way, my suggestion is that rules and headers should follow the same patterns. If one of them starts empty, then the other should do the same. (I'll happily implement both fixes if you'd like to).
- I created a `Headers && Rules tabs` section in the `ui-interactions.spec.ts` suite. During development, I was facing the issue that adding a rule did not update the respective tab label immediately, and I had to `pause` an arbitrary number of milliseconds in order for it to work smoothly. I am not experienced with angular or rxjs, so I suppose there is a better way to do it. Please advise and I will update the code accordingly.

**Checklist**

- [x] automated tests added
- [ ] data migration added (if applicable)
- [ ] data migration automated tests added (if applicable)
