### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ If you are interested in contributing to Mockoon, please take a look at the [con
 
 Please also take a look at our [Code of Conduct](https://github.com/mockoon/mockoon/blob/main/CODE_OF_CONDUCT.md).
 
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=mockoon/mockoon)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=mockoon/mockoon)
+
 ## Roadmap
 
 If you want to know what will be coming in the next release you can check the global [Roadmap](https://github.com/orgs/mockoon/projects/2).


### PR DESCRIPTION
Hi, community!

To better present how our community grows, we develop a tool to show contributors growing history on [https://github.com/api7/contributor-graph](https://github.com/api7/contributor-graph). Since we found it helpful, we think maybe if it could help some other community.

## WHAT IT IS

Basically, it just shows the contributors growth over time, just like the stargazers over time on the README. It would be the same with stars that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to play around with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/72343596/119219871-41a7ec80-bb1a-11eb-9a2e-4a660cf3b2c4.png)

## HOW IT WORKS 

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻