### PR TITLE
Closes mockoon/mockoon#469

### DIFF
--- a/src/renderer/app/app.component.html
+++ b/src/renderer/app/app.component.html
@@ -97,10 +97,9 @@
                 <span class="input-group-text"
                   ><i
                     class="material-icons"
-                    ngbTooltip="Server available on all network interfaces (localhost, 127.0.0.1, etc)"
+                    [ngbTooltip]="hostnameTooltip$ | async"
                     >power</i
-                  >
-                  0.0.0.0 :</span
+                  >&nbsp; {{ activeEnvironment.hostname }} :</span
                 >
               </div>
               <input
@@ -380,14 +379,14 @@
                 <!-- flexbox container -->
                 <div>
                   <app-title-separator
-                    heading="HTTPS"
-                    icon="https"
-                    iconClasses="text-warning"
+                    heading="Server Settings"
+                    icon="storage"
+                    iconClasses="text-primary"
                     docLink="https"
                   ></app-title-separator>
 
                   <div class="form-inline pl-4">
-                    <div class="custom-control custom-checkbox">
+                    <div class="custom-control custom-checkbox mr-4">
                       <input
                         type="checkbox"
                         class="custom-control-input"
@@ -395,7 +394,18 @@
                         formControlName="https"
                       />
                       <label class="custom-control-label" for="HTTPS"
-                        >Enable</label
+                        >HTTPS</label
+                      >
+                    </div>
+                    <div class="custom-control custom-checkbox">
+                      <input
+                        type="checkbox"
+                        class="custom-control-input"
+                        id="localhostOnly"
+                        formControlName="localhostOnly"
+                      />
+                      <label class="custom-control-label" for="localhostOnly"
+                        >Localhost Only</label
                       >
                     </div>
                   </div>

--- a/src/renderer/app/components/environments-menu/environments-menu.component.html
+++ b/src/renderer/app/components/environments-menu/environments-menu.component.html
@@ -71,7 +71,7 @@
                 class="menu-subtitle ellipsis"
               >
                 <span
-                  >0.0.0.0:{{ environment.port }}/{{
+                  >{{ environment.hostname }}:{{ environment.port }}/{{
                     environment.endpointPrefix
                   }}</span
                 >

--- a/src/renderer/app/constants/messages.constants.ts
+++ b/src/renderer/app/constants/messages.constants.ts
@@ -47,6 +47,18 @@ export const Messages: {
     showToast: true,
     toastType: 'error'
   }),
+  HOSTNAME_UNAVAILABLE: (messageParams) => ({
+    message: 'Provided hostname/address not available',
+    loggerMessage: `Error when starting the server ${messageParams.uuid}: ${messageParams.error.message}`,
+    showToast: true,
+    toastType: 'error'
+  }),
+  HOSTNAME_UNKNOWN: (messageParams) => ({
+    message: 'Unknown hostname/address provided',
+    loggerMessage: `Error getting address information ${messageParams.uuid}: ${messageParams.error.message}`,
+    showToast: true,
+    toastType: 'error'
+  }),
   REQUEST_BODY_PARSE: (messageParams) => {
     const message = `Error while parsing entering body: ${messageParams.error.message}`;
 

--- a/src/renderer/app/services/schemas-builder.service.ts
+++ b/src/renderer/app/services/schemas-builder.service.ts
@@ -81,6 +81,7 @@ export class SchemasBuilderService {
       endpointPrefix: '',
       latency: 0,
       port: this.dataService.getNewEnvironmentPort(),
+      hostname: '0.0.0.0',
       routes: hasDefaultRoute ? [this.buildRoute()] : [],
       proxyMode: false,
       proxyHost: '',

--- a/src/renderer/app/stores/reducer.ts
+++ b/src/renderer/app/stores/reducer.ts
@@ -474,6 +474,7 @@ export const environmentReducer = (
         'proxyHost',
         'proxyRemovePrefix',
         'https',
+        'hostname',
         'cors'
       ];
       const activeEnvironmentStatus =

--- a/test/data/environment-hostname-restriction/all/environments.json
+++ b/test/data/environment-hostname-restriction/all/environments.json
@@ -1,0 +1,44 @@
+[
+  {
+    "uuid": "c1a25f3c-9978-49f1-b0df-b4cd5860df5a",
+    "lastMigration": 15,
+    "name": "Hostname Test",
+    "endpointPrefix": "",
+    "latency": 0,
+    "port": 3000,
+    "routes": [
+      {
+        "uuid": "33352220-036b-4924-84b4-47c6eecf9662",
+        "method": "get",
+        "endpoint": "test",
+        "documentation": "Test Hostname",
+        "enabled": true,
+        "randomResponse": false,
+        "responses": [
+          {
+            "uuid": "a39bfcf1-6f67-40a6-8a7f-723f57c49619",
+            "body": "Response",
+            "latency": 0,
+            "statusCode": 200,
+            "label": "",
+            "headers": [{ "key": "Content-Type", "value": "text/plain" }],
+            "filePath": "",
+            "sendFileAsBody": false,
+            "rules": [],
+            "rulesOperator": "OR",
+            "disableTemplating": false
+          }
+        ],
+        "sequentialResponse": false
+      }
+    ],
+    "proxyMode": false,
+    "proxyHost": "",
+    "https": false,
+    "cors": true,
+    "headers": [{ "key": "", "value": "" }],
+    "proxyReqHeaders": [{ "key": "", "value": "" }],
+    "proxyResHeaders": [{ "key": "", "value": "" }],
+    "proxyRemovePrefix": false
+  }
+]

--- a/test/data/environment-hostname-restriction/localhost/environments.json
+++ b/test/data/environment-hostname-restriction/localhost/environments.json
@@ -1,0 +1,45 @@
+[
+  {
+    "uuid": "c1a25f3c-9978-49f1-b0df-b4cd5860df5a",
+    "lastMigration": 15,
+    "name": "Hostname Test",
+    "endpointPrefix": "",
+    "latency": 0,
+    "port": 3000,
+    "routes": [
+      {
+        "uuid": "33352220-036b-4924-84b4-47c6eecf9662",
+        "method": "get",
+        "endpoint": "test",
+        "documentation": "Test Hostname",
+        "enabled": true,
+        "randomResponse": false,
+        "responses": [
+          {
+            "uuid": "a39bfcf1-6f67-40a6-8a7f-723f57c49619",
+            "body": "Response",
+            "latency": 0,
+            "statusCode": 200,
+            "label": "",
+            "headers": [{ "key": "Content-Type", "value": "text/plain" }],
+            "filePath": "",
+            "sendFileAsBody": false,
+            "rules": [],
+            "rulesOperator": "OR",
+            "disableTemplating": false
+          }
+        ],
+        "sequentialResponse": false
+      }
+    ],
+    "proxyMode": false,
+    "proxyHost": "",
+    "hostname": "127.0.0.1",
+    "https": false,
+    "cors": true,
+    "headers": [{ "key": "", "value": "" }],
+    "proxyReqHeaders": [{ "key": "", "value": "" }],
+    "proxyResHeaders": [{ "key": "", "value": "" }],
+    "proxyRemovePrefix": false
+  }
+]

--- a/test/lib/fetch.ts
+++ b/test/lib/fetch.ts
@@ -8,6 +8,7 @@ const RequestsLibraries = {
 };
 
 export const fetch = (params: {
+  hostname: string;
   protocol: 'http' | 'https';
   port: number;
   path: string;
@@ -20,6 +21,8 @@ export const fetch = (params: {
     typeof params.body === 'string'
       ? params.body
       : JSON.stringify(params.body || {});
+
+  params.hostname = params.hostname ?? 'localhost';
 
   return new Promise((resolve, reject) => {
     const headers = {
@@ -35,7 +38,7 @@ export const fetch = (params: {
 
     const request = RequestsLibraries[params.protocol](
       {
-        hostname: 'localhost',
+        hostname: params.hostname,
         port: params.port,
         path: params.path,
         method: params.method.toUpperCase(),

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -418,10 +418,19 @@ export class Helpers {
   }
 
   public async httpCallAsserterWithPort(httpCall: HttpCall, port: number) {
+    await this.httpCallAssertWithPortAndHostname(httpCall, port, 'localhost');
+  }
+
+  public async httpCallAssertWithPortAndHostname(
+    httpCall: HttpCall,
+    port: number,
+    hostname: string
+  ) {
     // allow for UI changes to be propagated
     await this.testsInstance.app.client.pause(500);
 
     const response = await fetch({
+      hostname,
       protocol: httpCall.protocol || 'http',
       port,
       path: httpCall.path,

--- a/test/suites/environment-hostname-restriction.spec.ts
+++ b/test/suites/environment-hostname-restriction.spec.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import * as os from 'os';
+import { HttpCall } from 'test/lib/models';
+import { Tests } from 'test/lib/tests';
+
+const endpointCall: HttpCall = {
+  description: 'Call GET /test',
+  path: '/test',
+  method: 'GET',
+  body: 'requestbody',
+  testedResponse: {
+    body: 'Response',
+    status: 200
+  }
+};
+
+describe('Environment answers on all hostnames', async () => {
+  const tests = new Tests('environment-hostname-restriction/all');
+
+  it('Start default environment', async () => {
+    await tests.helpers.startEnvironment();
+  });
+
+  it(endpointCall.description, async () => {
+    await tests.helpers.httpCallAsserter(endpointCall);
+  });
+
+  const nics = os.networkInterfaces();
+
+  const testedNicTypes = ['wi-fi', 'ethernet'];
+
+  it('Answers on localhost', async () => {
+    await tests.helpers.httpCallAssertWithPortAndHostname(
+      endpointCall,
+      3000,
+      'localhost'
+    );
+  });
+
+  it('Answers on 127.0.0.1', async () => {
+    await tests.helpers.httpCallAssertWithPortAndHostname(
+      endpointCall,
+      3000,
+      '127.0.0.1'
+    );
+  });
+
+  for (const nicType in nics) {
+    if (testedNicTypes.indexOf(nicType.toLowerCase()) === -1) {
+      continue;
+    }
+    for (const address of nics[nicType]) {
+      if (address.family !== 'IPv4') {
+        continue;
+      }
+
+      it(`Answers on ${address.address}`, async () => {
+        await tests.helpers.httpCallAssertWithPortAndHostname(
+          endpointCall,
+          3000,
+          address.address
+        );
+      });
+    }
+  }
+});
+
+describe('Environment answers on localhost only', async () => {
+  const tests = new Tests('environment-hostname-restriction/localhost');
+
+  it('Start default environment', async () => {
+    await tests.helpers.startEnvironment();
+  });
+
+  it(endpointCall.description, async () => {
+    await tests.helpers.httpCallAsserter(endpointCall);
+  });
+
+  it('Answers on localhost', async () => {
+    await tests.helpers.httpCallAssertWithPortAndHostname(
+      endpointCall,
+      3000,
+      'localhost'
+    );
+  });
+
+  it('Answers on 127.0.0.1', async () => {
+    await tests.helpers.httpCallAssertWithPortAndHostname(
+      endpointCall,
+      3000,
+      '127.0.0.1'
+    );
+  });
+
+  const nics = os.networkInterfaces();
+
+  const testedNicTypes = ['wi-fi', 'ethernet'];
+
+  for (const nicType in nics) {
+    if (testedNicTypes.indexOf(nicType.toLowerCase()) === -1) {
+      continue;
+    }
+    for (const address of nics[nicType]) {
+      if (address.family !== 'IPv4') {
+        continue;
+      }
+
+      it(`Does not answer on ${address.address}`, async () => {
+        await expect(
+          tests.helpers.httpCallAssertWithPortAndHostname(
+            endpointCall,
+            3000,
+            address.address
+          )
+        ).to.be.rejectedWith(Error);
+      });
+    }
+  }
+});

--- a/test/suites/environment-hostname-restriction.spec.ts
+++ b/test/suites/environment-hostname-restriction.spec.ts
@@ -49,11 +49,8 @@ describe('Environment answers on all hostnames', async () => {
     if (testedNicTypes.indexOf(nicType.toLowerCase()) === -1) {
       continue;
     }
-    for (const address of nics[nicType]) {
-      if (address.family !== 'IPv4') {
-        continue;
-      }
 
+    for (const address of nics[nicType].filter((f) => f.family === 'IPv4')) {
       it(`Answers on ${address.address}`, async () => {
         await tests.helpers.httpCallAssertWithPortAndHostname(
           endpointCall,
@@ -100,11 +97,7 @@ describe('Environment answers on localhost only', async () => {
     if (testedNicTypes.indexOf(nicType.toLowerCase()) === -1) {
       continue;
     }
-    for (const address of nics[nicType]) {
-      if (address.family !== 'IPv4') {
-        continue;
-      }
-
+    for (const address of nics[nicType].filter((a) => a.family === 'IPv4')) {
       it(`Does not answer on ${address.address}`, async () => {
         await expect(
           tests.helpers.httpCallAssertWithPortAndHostname(

--- a/test/suites/migrations.spec.ts
+++ b/test/suites/migrations.spec.ts
@@ -141,4 +141,19 @@ describe('Environments migrations', () => {
       );
     });
   });
+
+  describe('No. 16', () => {
+    const filesPath = 'migrations/16';
+    const tests = new Tests(filesPath);
+
+    it('Should add "hostname" properties to environments', async () => {
+      await tests.helpers.waitForAutosave();
+
+      await tests.helpers.verifyObjectPropertyInFile(
+        './tmp/storage/environments.json',
+        ['0.hostname'],
+        '0.0.0.0'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #469 
Changes HTTPS settings to Server Settings
Changes Enable checkbox to HTTPS
Adds Localhost Only checkbox under Server Settings
Makes the environments menu show the configured hostname instead of a static 0.0.0.0

The Localhost Only checkbox just determines if 127.0.0.1 or 0.0.0.0 gets set as the hostname configuration value.