### PR TITLE
Fix "duplicate to environment" UI when the env is unnamed

### DIFF
--- a/src/renderer/app/components/move-route-modal/duplicate-route-modal.component.html
+++ b/src/renderer/app/components/move-route-modal/duplicate-route-modal.component.html
@@ -23,6 +23,11 @@
         (click)="chooseTargetEnvironment(environment)"
       >
         <div class="ellipsis">{{ environment.name }}</div>
+        <div class="menu-subtitle ellipsis">
+          {{ environment.hostname }}:{{ environment.port }}/{{
+            environment.endpointPrefix
+          }}
+        </div>
       </li>
     </ul>
   </div>

--- a/test/suites/routes-duplicate-to-env.spec.ts
+++ b/test/suites/routes-duplicate-to-env.spec.ts
@@ -3,8 +3,11 @@ import { Tests } from 'test/lib/tests';
 
 describe('Duplicate a route to an environment', async () => {
   const { helpers } = new Tests('basic-data');
-  const firstEnvSelector =
-    '.modal-content .modal-body .list-group .list-group-item:first-child';
+
+  const envNameSelector =
+    '.modal-content .modal-body .list-group .list-group-item:first-child div:first-of-type';
+  const envHostnameSelector =
+    '.modal-content .modal-body .list-group .list-group-item:first-child div:last-of-type';
 
   it('should assert that menu entry is disabled when only one environment present', async () => {
     await helpers.assertContextMenuDisabled(
@@ -41,15 +44,17 @@ describe('Duplicate a route to an environment', async () => {
 
     expect(targetRoute).to.include('POST /dolphins');
 
-    const targetEnvironmentName = await helpers.getElementText(
-      firstEnvSelector
-    );
-
+    const targetEnvironmentName = await helpers.getElementText(envNameSelector);
     expect(targetEnvironmentName).to.equal('New environment');
+
+    const targetEnvironmentHostname = await helpers.getElementText(
+      envHostnameSelector
+    );
+    expect(targetEnvironmentHostname).to.equal('0.0.0.0:3001/');
   });
 
   it('should duplicate selected route to selected environment', async () => {
-    await helpers.elementClick(firstEnvSelector);
+    await helpers.elementClick(envNameSelector);
 
     await helpers.assertActiveEnvironmentName('New environment');
     await helpers.checkActiveRoute('POST\n/dolphins');


### PR DESCRIPTION
Add test for the display of hostname and port
Closes #532

<!-- 
IMPORTANT RULES: 
- Read the contributing guidelines first!
- All pull requests must be linked to an issue.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development. 
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide: https://chris.beams.io/posts/git-commit/
- Follow the branch naming convention.
- Follow the template!
 -->

**Parent issue** 

Closes #[insert_issue_number_here]

**Technical implementation details**

<!-- Describe your implementation in details -->

**Checklist**

- [ ] automated tests added
- [ ] data migration added (if applicable)
- [ ] data migration automated tests added (if applicable)
