### PR TITLE
Add cookie as Response Rule Target

### DIFF
--- a/src/renderer/app/components/route-response-rules/route-response-rules.component.html
+++ b/src/renderer/app/components/route-response-rules/route-response-rules.component.html
@@ -99,12 +99,10 @@
                     operatorFormControl.value === responseRuleOperator.code
                   "
                   [attr.disabled]="
-                    form.get(['rules', ruleIndex, 'target']).value ===
-                      'request_number' &&
-                    (responseRuleOperator.code === 'null' ||
-                      responseRuleOperator.code === 'empty_array')
-                      ? true
-                      : null
+                    shouldOperatorBeDisabled(
+                      form.get(['rules', ruleIndex, 'target']).value,
+                      responseRuleOperator.code
+                    )
                   "
                 >
                   {{ responseRuleOperator.text }}

--- a/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
+++ b/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
@@ -48,6 +48,7 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     { code: 'body', text: 'Body' },
     { code: 'query', text: 'Query string' },
     { code: 'header', text: 'Header' },
+    { code: 'cookie', text: 'Cookie' },
     { code: 'params', text: 'Route params' },
     { code: 'request_number', text: 'Request number (starting at 1)' }
   ];
@@ -61,6 +62,7 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     body: 'Object path or empty for full body',
     query: 'Property name or object path',
     header: 'Header name',
+    cookie: 'Cookie name',
     params: 'Route parameter name',
     request_number: ''
   };
@@ -69,6 +71,10 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     regex: 'Regex (without /../)',
     null: '',
     empty_array: ''
+  };
+  public operatorDisablingForTargets = {
+    request_number: ['null', 'empty_array'],
+    cookie: ['empty_array']
   };
   public rulesOperatorsList: LogicalOperators[] = ['OR', 'AND'];
   private listenToChanges = true;
@@ -126,6 +132,18 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     );
 
     this.ruleAdded.emit();
+  }
+
+  public shouldOperatorBeDisabled(
+    target: string,
+    operator: ResponseRuleOperators
+  ): boolean {
+    const disablingTargets = this.operatorDisablingForTargets[target];
+    if (!disablingTargets) {
+      return null;
+    }
+
+    return disablingTargets.includes(operator) ? true : null;
   }
 
   public reorderResponseRules(event: CdkDragDrop<string[]>) {


### PR DESCRIPTION
**Parent issue** 

Closes #475

**Technical implementation details**

This feature enables the possibility to ask for specific Cookie values. It is inside the Response Rule Target Dropdown like Header and body.
This features disables the Rule Operator empty_array if cookie is chosen as target.
This feature is nearly similar to the Header target.
closes #

**Checklist**

- [ x ] automated tests added
