### PR TITLE
Fix `faker` helper returning a SafeString

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/faker-wrapper.ts
+++ b/packages/commons-server/src/libs/templating-helpers/faker-wrapper.ts
@@ -1,5 +1,5 @@
 import faker from '@faker-js/faker';
-import { HelperOptions, SafeString } from 'handlebars';
+import { HelperOptions } from 'handlebars';
 import { IsEmpty } from '../utils';
 
 export const FakerWrapper = {
@@ -57,6 +57,6 @@ export const FakerWrapper = {
       fakedContent = JSON.stringify(fakedContent);
     }
 
-    return new SafeString(fakedContent);
+    return fakedContent;
   }
 };

--- a/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
@@ -5,33 +5,6 @@ import { TemplateParser } from '../../../src/libs/template-parser';
 faker.seed(1);
 
 describe('Template parser: Faker wrapper', () => {
-  it('should return value for simple helper', () => {
-    const parseResult = TemplateParser(
-      "{{faker 'name.firstName'}}",
-      {} as any,
-      {} as any
-    );
-    expect(parseResult).to.be.equal('Hayden');
-  });
-
-  it('should return value for helper with named parameters', () => {
-    const parseResult = TemplateParser(
-      "{{faker 'datatype.number' min=10 max=20}}",
-      {} as any,
-      {} as any
-    );
-    expect(parseResult).to.be.equal('20');
-  });
-
-  it('should return value for helper with arguments', () => {
-    const parseResult = TemplateParser(
-      "{{faker 'random.alphaNumeric' 1}}",
-      {} as any,
-      {} as any
-    );
-    expect(parseResult).to.be.equal('p');
-  });
-
   it('should throw if helper name is missing', () => {
     expect(() => {
       TemplateParser('{{faker}}', {} as any, {} as any);
@@ -66,5 +39,77 @@ describe('Template parser: Faker wrapper', () => {
     }).to.throw(
       'donotexists.donotexists is not a valid Faker method (valid: "address.zipCode", "date.past", etc) line 1'
     );
+  });
+
+  it('should return value for simple helper', () => {
+    const parseResult = TemplateParser(
+      "{{faker 'name.firstName'}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('Hayden');
+  });
+
+  it('should return value for helper with named parameters', () => {
+    const parseResult = TemplateParser(
+      "{{faker 'datatype.number' min=10 max=20}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('20');
+  });
+
+  it('should return value for helper with arguments', () => {
+    const parseResult = TemplateParser(
+      "{{faker 'random.alphaNumeric' 1}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('p');
+  });
+
+  it('should be able to use a string value in a switch', () => {
+    const parseResult = TemplateParser(
+      "{{#switch (faker 'name.firstName')}}{{#case 'Torey'}}Torey{{/case}}{{#default}}defaultvalue{{/default}}{{/switch}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('Torey');
+  });
+
+  it('should be able to use a number value in a repeat', () => {
+    const parseResult = TemplateParser(
+      "{{#repeat (faker 'datatype.number' min=5 max=10) comma=false}}test{{/repeat}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('testtesttesttesttest');
+  });
+
+  it('should be able to use a number value in a setvar and reuse the setvar', () => {
+    const parseResult = TemplateParser(
+      "{{setVar 'nb' (faker 'datatype.number' min=5 max=10)}}{{nb}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('5');
+  });
+
+  it('should be able to use a number value in a setvar and reuse the variable in a helper requiring a number (int)', () => {
+    const parseResult = TemplateParser(
+      "{{setVar 'nb' (faker 'datatype.number' min=50 max=100)}}{{nb}}{{int 10 nb}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('6565');
+  });
+
+  it('should be able to use a boolean value in a if', () => {
+    const parseResult = TemplateParser(
+      "{{#if (faker 'datatype.boolean')}}activated{{else}}deactivated{{/if}}",
+      {} as any,
+      {} as any
+    );
+    expect(parseResult).to.be.equal('deactivated');
   });
 });


### PR DESCRIPTION
-Make the Faker wrapper returns the actual faker's function value (string, number, etc.). Like this, the `faker` helper is compatible with other helpers that needs other things than strings (`int`, `if`, etc.)
Closes #699

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
