### PR TITLE
Fix `setVar` helper not working in nested block helpers

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers.ts
@@ -24,18 +24,17 @@ import {
  * args[args.length - 1]
  */
 export const Helpers = {
-  repeat: function (min: number, max: number, options: HelperOptions | any) {
+  repeat: function (...args: any[]) {
     let content = '';
     let count = 0;
+    const options = args[args.length - 1];
     const data = { ...options };
 
     if (arguments.length === 3) {
       // If given two numbers then pick a random one between the two
-      count = RandomInt(min, max);
+      count = RandomInt(args[0], args[1]);
     } else if (arguments.length === 2) {
-      // If given one number then just use it as a fixed repeat total
-      options = max;
-      count = min;
+      count = args[0];
     } else {
       throw new Error('The repeat helper requires a numeric param');
     }
@@ -443,7 +442,7 @@ export const Helpers = {
     return number1 <= number2;
   },
   // set a variable to be used in the template
-  setVar: function (name: string, value: unknown, options: HelperOptions) {
+  setVar: function (name: string, value: unknown) {
     if (typeof name === 'object') {
       return;
     }
@@ -453,12 +452,7 @@ export const Helpers = {
       return;
     }
 
-    // we are at the root level
-    if (options.data.root) {
-      options.data.root[name] = value;
-    } else {
-      options.data[name] = value;
-    }
+    this[name] = value;
   },
   int: function (...args: any[]) {
     const options: { min?: number; max?: number; precision?: number } = {

--- a/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
@@ -155,7 +155,7 @@ describe('Template parser', () => {
 
     it('should set a variable in a different scope: repeat', () => {
       const parseResult = TemplateParser(
-        "{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{@testvar}}{{/repeat}}",
+        "{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{testvar}}{{/repeat}}",
         {} as any,
         {} as any
       );
@@ -164,11 +164,20 @@ describe('Template parser', () => {
 
     it('should set a variable in root scope and child scope: repeat', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'outsidevar' 'test'}}{{@root.outsidevar}}{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{@testvar}}{{outsidevar}}{{/repeat}}",
+        "{{setVar 'outsidevar' 'test'}}{{outsidevar}}{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{testvar}}{{outsidevar}}{{/repeat}}",
         {} as any,
         {} as any
       );
       expect(parseResult).to.be.equal('test0test1test2test3test4test');
+    });
+
+    it('should set variables in two nested repeat', () => {
+      const parseResult = TemplateParser(
+        "{{#repeat 1 comma=false}}{{setVar 'itemId' 25}}Item:{{itemId}}{{setVar 'nb' 1}}{{#repeat nb comma=false}}{{setVar 'childId' 56}}Child:{{childId}}parent:{{itemId}}{{/repeat}}{{/repeat}}",
+        {} as any,
+        {} as any
+      );
+      expect(parseResult).to.be.equal('Item:25Child:56parent:25');
     });
 
     it('should set a variable to empty value if none provided', () => {


### PR DESCRIPTION
Also fix the `repeat` helper overwriting nested contexts. 
Closes #706

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
