### PR TITLE
Fix `setVar` not working in `each`

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers.ts
@@ -28,7 +28,7 @@ export const Helpers = {
     let content = '';
     let count = 0;
     const options = args[args.length - 1];
-    const data = { ...options };
+    const data = { ...options.data };
 
     if (arguments.length === 3) {
       // If given two numbers then pick a random one between the two
@@ -460,17 +460,21 @@ export const Helpers = {
     return number1 <= number2;
   },
   // set a variable to be used in the template
-  setVar: function (name: string, value: unknown) {
-    if (typeof name === 'object') {
-      return;
-    }
-
+  setVar: function (...args: any[]) {
     // return if not all parameters have been provided
     if (arguments.length < 3) {
       return;
     }
 
-    this[name] = value;
+    const options = args[args.length - 1];
+    const name = args[0];
+    const value = args[1];
+
+    if (!options.data) {
+      options.data = {};
+    }
+
+    options.data[name] = value;
   },
   int: function (...args: any[]) {
     const options: { min?: number; max?: number; precision?: number } = {

--- a/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
@@ -88,7 +88,7 @@ describe('Template parser: Faker wrapper', () => {
 
   it('should be able to use a number value in a setvar and reuse the setvar', () => {
     const parseResult = TemplateParser(
-      "{{setVar 'nb' (faker 'datatype.number' min=5 max=10)}}{{nb}}",
+      "{{setVar 'nb' (faker 'datatype.number' min=5 max=10)}}{{@nb}}",
       {} as any,
       {} as any
     );
@@ -97,7 +97,7 @@ describe('Template parser: Faker wrapper', () => {
 
   it('should be able to use a number value in a setvar and reuse the variable in a helper requiring a number (int)', () => {
     const parseResult = TemplateParser(
-      "{{setVar 'nb' (faker 'datatype.number' min=50 max=100)}}{{nb}}{{int 10 nb}}",
+      "{{setVar 'nb' (faker 'datatype.number' min=50 max=100)}}{{@nb}}{{int 10 @nb}}",
       {} as any,
       {} as any
     );

--- a/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
@@ -111,7 +111,7 @@ describe('Template parser', () => {
   describe('Helper: setVar', () => {
     it('should set a variable to a string', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 'testvalue'}}{{testvar}}",
+        "{{setVar 'testvar' 'testvalue'}}{{@testvar}}",
         {} as any,
         {} as any
       );
@@ -120,7 +120,7 @@ describe('Template parser', () => {
 
     it('should set a variable to a number', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 123}}{{testvar}}",
+        "{{setVar 'testvar' 123}}{{@testvar}}",
         {} as any,
         {} as any
       );
@@ -129,7 +129,7 @@ describe('Template parser', () => {
 
     it('should set a variable value to body helper result', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' (body 'uuid')}}{{testvar}}",
+        "{{setVar 'testvar' (body 'uuid')}}{{@testvar}}",
         {
           body: { uuid: '0d35618e-5e85-4c09-864d-6d63973271c8' }
         } as any,
@@ -140,7 +140,7 @@ describe('Template parser', () => {
 
     it('should set a variable value to oneOf helper result', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' (oneOf (array 'item1'))}}{{testvar}}",
+        "{{setVar 'testvar' (oneOf (array 'item1'))}}{{@testvar}}",
         {} as any,
         {} as any
       );
@@ -149,7 +149,7 @@ describe('Template parser', () => {
 
     it('should set a variable and use it in another helper', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 5}}{{#repeat testvar comma=false}}test{{/repeat}}",
+        "{{setVar 'testvar' 5}}{{#repeat @testvar comma=false}}test{{/repeat}}",
         {} as any,
         {} as any
       );
@@ -158,7 +158,7 @@ describe('Template parser', () => {
 
     it('should set a variable in a different scope: repeat', () => {
       const parseResult = TemplateParser(
-        "{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{testvar}}{{/repeat}}",
+        "{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{@testvar}}{{/repeat}}",
         {} as any,
         {} as any
       );
@@ -167,7 +167,7 @@ describe('Template parser', () => {
 
     it('should set a variable in root scope and child scope: repeat', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'outsidevar' 'test'}}{{outsidevar}}{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{testvar}}{{outsidevar}}{{/repeat}}",
+        "{{setVar 'outsidevar' 'test'}}{{@outsidevar}}{{#repeat 5 comma=false}}{{setVar 'testvar' @index}}{{@testvar}}{{@outsidevar}}{{/repeat}}",
         {} as any,
         {} as any
       );
@@ -176,16 +176,47 @@ describe('Template parser', () => {
 
     it('should set variables in two nested repeat', () => {
       const parseResult = TemplateParser(
-        "{{#repeat 1 comma=false}}{{setVar 'itemId' 25}}Item:{{itemId}}{{setVar 'nb' 1}}{{#repeat nb comma=false}}{{setVar 'childId' 56}}Child:{{childId}}parent:{{itemId}}{{/repeat}}{{/repeat}}",
+        "{{#repeat 1 comma=false}}{{setVar 'itemId' 25}}Item:{{@itemId}}{{setVar 'nb' 1}}{{#repeat @nb comma=false}}{{setVar 'childId' 56}}Child:{{@childId}}parent:{{@itemId}}{{/repeat}}{{/repeat}}",
         {} as any,
         {} as any
       );
       expect(parseResult).to.be.equal('Item:25Child:56parent:25');
     });
 
+    it('should set variables in a each', () => {
+      const parseResult = TemplateParser(
+        "{{#each (split '1 2')}}{{setVar 'item' this}}{{@item}}{{/each}}",
+        {} as any,
+        {} as any
+      );
+      expect(parseResult).to.be.equal('12');
+    });
+
+    it('should set variables in a each in a repeat', () => {
+      const parseResult = TemplateParser(
+        "{{#repeat 2 comma=false}}{{setVar 'repeatvar' 'repeatvarvalue'}}{{#each (split '1 2')}}{{setVar 'item' this}}{{@repeatvar}}{{@item}}{{/each}}{{/repeat}}",
+        {} as any,
+        {} as any
+      );
+      expect(parseResult).to.be.equal(
+        'repeatvarvalue1repeatvarvalue2repeatvarvalue1repeatvarvalue2'
+      );
+    });
+
+    it('should set variables in two each', () => {
+      const parseResult = TemplateParser(
+        "{{#each (split '1 2')}}{{setVar 'each1var' 'each1varvalue'}}{{#each (split '1 2')}}{{setVar 'each2var' this}}{{@each1var}}{{@each2var}}{{/each}}{{/each}}",
+        {} as any,
+        {} as any
+      );
+      expect(parseResult).to.be.equal(
+        'each1varvalue1each1varvalue2each1varvalue1each1varvalue2'
+      );
+    });
+
     it('should set a variable to empty value if none provided', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar'}}{{testvar}}",
+        "{{setVar 'testvar'}}{{@testvar}}",
         {} as any,
         {} as any
       );
@@ -194,7 +225,7 @@ describe('Template parser', () => {
 
     it('should not set a variable if no name provided', () => {
       const parseResult = TemplateParser(
-        "{{setVar ''}}{{testvar}}",
+        "{{setVar ''}}{{@testvar}}",
         {} as any,
         {} as any
       );
@@ -414,7 +445,7 @@ describe('Template parser', () => {
 
     it('Should work correctly when variables are passed as parameters as numbers', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 'testdata'}}{{setVar 'from' 4}}{{setVar 'length' 4}}{{substr testvar from length}}",
+        "{{setVar 'testvar' 'testdata'}}{{setVar 'from' 4}}{{setVar 'length' 4}}{{substr @testvar @from @length}}",
         {} as any,
         {} as any
       );
@@ -424,7 +455,7 @@ describe('Template parser', () => {
 
     it('Should work correctly when variables are passed as parameters as strings', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 'testdata'}}{{setVar 'from' '4'}}{{setVar 'length' '4'}}{{substr testvar from length}}",
+        "{{setVar 'testvar' 'testdata'}}{{setVar 'from' '4'}}{{setVar 'length' '4'}}{{substr @testvar @from @length}}",
         {} as any,
         {} as any
       );
@@ -775,7 +806,7 @@ describe('Template parser', () => {
 
     it('Can return the index from a previously set variable', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 'this is a test'}}{{indexOf testvar 'test'}}",
+        "{{setVar 'testvar' 'this is a test'}}{{indexOf @testvar 'test'}}",
         {} as any,
         {} as any
       );
@@ -785,7 +816,7 @@ describe('Template parser', () => {
 
     it('Can return the index from a previously set variable using a variable for the search string', () => {
       const parseResult = TemplateParser(
-        "{{setVar 'testvar' 'this is a test'}}{{setVar 'searchstring' 'test'}}{{indexOf testvar searchstring}}",
+        "{{setVar 'testvar' 'this is a test'}}{{setVar 'searchstring' 'test'}}{{indexOf @testvar @searchstring}}",
         {} as any,
         {} as any
       );


### PR DESCRIPTION
Revert to using `options.data` instead of `this` or `root` due to incompatibility between Handlebars' `each` implementation and `repeat`. Now all variables are scoped and available by using `@`.
Closes #793

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
