### PR TITLE
Add response.statusMessage data information in environment logs

### DIFF
--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -131,6 +131,7 @@ export function CreateTransaction(
     },
     response: {
       statusCode: response.statusCode,
+      statusMessage: response.statusMessage,
       headers: TransformHeaders(response.getHeaders()).sort(AscSort),
       body: DecompressBody(response)
     },

--- a/packages/commons/src/models/server.model.ts
+++ b/packages/commons/src/models/server.model.ts
@@ -43,6 +43,7 @@ export type Transaction = {
   };
   response: {
     statusCode: number;
+    statusMessage: string;
     headers: Header[];
     body: string;
   };

--- a/packages/desktop/src/renderer/app/components/environment-logs/environment-logs.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-logs/environment-logs.component.html
@@ -328,6 +328,9 @@
                   <div class="environment-logs-content-item">
                     <strong>Status:</strong> {{ selectedLog.response?.status }}
                   </div>
+                  <div class="environment-logs-content-item">
+                    <strong>StatusMessage:</strong> {{ selectedLog.response?.statusMessage }}
+                  </div>
                 </div>
 
                 <!-- Response Headers -->

--- a/packages/desktop/src/renderer/app/components/environment-logs/environment-logs.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-logs/environment-logs.component.html
@@ -326,10 +326,14 @@
                 </div>
                 <div [ngbCollapse]="collapseStates['response.general']">
                   <div class="environment-logs-content-item">
-                    <strong>Status:</strong> {{ selectedLog.response?.status }}
-                  </div>
-                  <div class="environment-logs-content-item">
-                    <strong>StatusMessage:</strong> {{ selectedLog.response?.statusMessage }}
+                    <strong>Status:</strong>
+                    {{
+                      selectedLog.response
+                        ? selectedLog.response.status +
+                          ' - ' +
+                          selectedLog.response.statusMessage
+                        : ''
+                    }}
                   </div>
                 </div>
 

--- a/packages/desktop/src/renderer/app/models/environment-logs.model.ts
+++ b/packages/desktop/src/renderer/app/models/environment-logs.model.ts
@@ -13,6 +13,7 @@ export type EnvironmentLogRequest = {
 
 export type EnvironmentLogResponse = {
   status: number;
+  statusMessage: string;
   headers: Header[];
   body: string;
   truncatedBody?: string;

--- a/packages/desktop/src/renderer/app/services/data.service.ts
+++ b/packages/desktop/src/renderer/app/services/data.service.ts
@@ -81,6 +81,7 @@ export class DataService extends Logger {
       proxied: transaction.proxied,
       response: {
         status: transaction.response.statusCode,
+        statusMessage: transaction.response.statusMessage,
         headers: transaction.response.headers,
         body: transaction.response.body,
         binaryBody: transaction.response.body === BINARY_BODY

--- a/packages/desktop/test/libs/http.ts
+++ b/packages/desktop/test/libs/http.ts
@@ -127,6 +127,7 @@ class Http {
           response.on('end', () =>
             resolve({
               status: response.statusCode,
+              statusMessage: response.statusMessage,
               headers: response.headers,
               body,
               cert: (response?.connection as any).getPeerCertificate

--- a/packages/desktop/test/libs/models.ts
+++ b/packages/desktop/test/libs/models.ts
@@ -1,6 +1,7 @@
 export type HttpCallResponse = {
   body?: string | { contains: string } | RegExp;
   status?: number;
+  statusMessage?: string;
   headers?: {
     [key in string]: string | string[];
   };

--- a/packages/desktop/test/specs/environment-logs.spec.ts
+++ b/packages/desktop/test/specs/environment-logs.spec.ts
@@ -15,7 +15,8 @@ const endpointCall: HttpCall = {
   body: 'requestbody',
   testedResponse: {
     body: 'responsebody',
-    status: 200
+    status: 200,
+    statusMessage: 'OK'
   }
 };
 
@@ -25,7 +26,8 @@ const endpointCall2: HttpCall = {
   method: 'GET',
   testedResponse: {
     body: 'created',
-    status: 201
+    status: 201,
+    statusMessage: 'Created'
   }
 };
 
@@ -34,7 +36,8 @@ const errorCall: HttpCall = {
   path: '/prefix/test',
   method: 'GET',
   testedResponse: {
-    status: 404
+    status: 404,
+    statusMessage: 'Not Found'
   }
 };
 
@@ -43,7 +46,8 @@ const binaryCall: HttpCall = {
   path: '/prefix/file',
   method: 'GET',
   testedResponse: {
-    status: 200
+    status: 200,
+    statusMessage: 'OK'
   }
 };
 
@@ -141,6 +145,12 @@ describe('Environment logs', () => {
         await environmentsLogs.switchTab('RESPONSE');
         await environmentsLogs.assertLogItem('Status: 200', 'response', 2, 1);
         await environmentsLogs.assertLogItem(
+          'StatusMessage: OK',
+          'response',
+          2,
+          2
+        );
+        await environmentsLogs.assertLogItem(
           'Content-length: 12',
           'response',
           4,
@@ -191,6 +201,12 @@ describe('Environment logs', () => {
       it('should verify response tab content', async () => {
         await environmentsLogs.switchTab('RESPONSE');
         await environmentsLogs.assertLogItem('Status: 404', 'response', 2, 1);
+        await environmentsLogs.assertLogItem(
+          'StatusMessage: Not Found',
+          'response',
+          2,
+          2
+        );
         await environmentsLogs.assertLogItem(
           'Content-length: 150',
           'response',
@@ -321,6 +337,12 @@ describe('Environment logs', () => {
       await navigation.switchView('ENV_LOGS');
       await environmentsLogs.assertActiveLogEntry(2);
       await environmentsLogs.assertLogItem('Status: 200', 'response', 2, 1);
+      await environmentsLogs.assertLogItem(
+        'StatusMessage: OK',
+        'response',
+        2,
+        2
+      );
       await environmentsLogs.assertLogItem(' responsebody ', 'response', 6, 1);
     });
   });

--- a/packages/desktop/test/specs/environment-logs.spec.ts
+++ b/packages/desktop/test/specs/environment-logs.spec.ts
@@ -143,12 +143,11 @@ describe('Environment logs', () => {
 
       it('should verify response tab content', async () => {
         await environmentsLogs.switchTab('RESPONSE');
-        await environmentsLogs.assertLogItem('Status: 200', 'response', 2, 1);
         await environmentsLogs.assertLogItem(
-          'StatusMessage: OK',
+          'Status: 200 - OK',
           'response',
           2,
-          2
+          1
         );
         await environmentsLogs.assertLogItem(
           'Content-length: 12',
@@ -200,12 +199,11 @@ describe('Environment logs', () => {
 
       it('should verify response tab content', async () => {
         await environmentsLogs.switchTab('RESPONSE');
-        await environmentsLogs.assertLogItem('Status: 404', 'response', 2, 1);
         await environmentsLogs.assertLogItem(
-          'StatusMessage: Not Found',
+          'Status: 404 - Not Found',
           'response',
           2,
-          2
+          1
         );
         await environmentsLogs.assertLogItem(
           'Content-length: 150',
@@ -274,7 +272,12 @@ describe('Environment logs', () => {
 
       it('should verify response tab content', async () => {
         await environmentsLogs.switchTab('RESPONSE');
-        await environmentsLogs.assertLogItem('Status: 200', 'response', 2, 1);
+        await environmentsLogs.assertLogItem(
+          'Status: 200 - OK',
+          'response',
+          2,
+          1
+        );
         await environmentsLogs.assertLogItem(
           'Content-length: 8696',
           'response',
@@ -336,12 +339,11 @@ describe('Environment logs', () => {
     it('should assert presence on log page and verify selected entry', async () => {
       await navigation.switchView('ENV_LOGS');
       await environmentsLogs.assertActiveLogEntry(2);
-      await environmentsLogs.assertLogItem('Status: 200', 'response', 2, 1);
       await environmentsLogs.assertLogItem(
-        'StatusMessage: OK',
+        'Status: 200 - OK',
         'response',
         2,
-        2
+        1
       );
       await environmentsLogs.assertLogItem(' responsebody ', 'response', 6, 1);
     });


### PR DESCRIPTION
Closes #852

**Technical implementation details**
I've been added a new property  `statusMessage` in `Transaction.response` located in `packages\commons\src\models\server.model.ts` for getting the statusMessage in "Logs" tab and some other places:
 - `function CreateTransaction` in packages\commons-server\src\libs\utils.ts that converts a pair of `Request` and `Response` objects in a `Transaction` object
 - `EnvironmentLogResponse` in packages\desktop\src\renderer\app\models\environment-logs.model.ts for showing the information from modified `Transaction` in "Logs" tab
 - `function formatLog` in packages\desktop\src\renderer\app\services\data.service.ts for converting the `Transaction` object in 
`EnvironmentLogResponse` object.
- added a new item in "General" section of "Response" tab in packages\desktop\src\renderer\app\components\environment-logs\environment-logs.component.html
- updated existing tests for covering my changes.


**Disclaimer:**
I'm not an experienced open software contributor or at least a JS developer, but I want to help you, Mockoon supporters, to make Mockoon better.

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
