### PR TITLE
Add dateFormat helper

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers.ts
@@ -525,6 +525,24 @@ export const Helpers = {
 
     return '';
   },
+  // Format a date and time to a specific format
+  dateFormat: function (...args: any[]) {
+    const date = fromSafeString(args[0]);
+    const format = fromSafeString(args[1]);
+
+    if (
+      args.length >= 2 &&
+      typeof date === 'string' &&
+      typeof format === 'string'
+    ) {
+      return dateFormat(new Date(date), format, {
+        useAdditionalWeekYearTokens: true,
+        useAdditionalDayOfYearTokens: true
+      });
+    }
+
+    return '';
+  },
   time: function (...args: any[]) {
     let from, to, format;
 

--- a/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
@@ -340,6 +340,43 @@ describe('Template parser', () => {
     });
   });
 
+  describe('Helper: dateFormat', () => {
+    it('Should return an empty string if given the wrong amount of arguments', () => {
+      const parseResult = TemplateParser(
+        false,
+        '{{dateFormat}}',
+        {} as any,
+        [],
+        {} as any
+      );
+      expect(parseResult).to.be.equal('');
+    });
+
+    it('Should return an empty string if given the wrong amount of arguments', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{dateFormat '2022-01-01'}}",
+        {} as any,
+        [],
+        {} as any
+      );
+
+      expect(parseResult).to.be.equal('');
+    });
+
+    it('Should return a date using a given format', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{dateFormat '2022-02-01' 'YYYY'}}",
+        {} as any,
+        [],
+        {} as any
+      );
+
+      expect(parseResult).to.be.equal('2022');
+    });
+  });
+
   describe('Helper: dateTimeShift', () => {
     it('Should not throw an error when passed with invalid parameters.', () => {
       const parseResult = TemplateParser(


### PR DESCRIPTION
Closes #873

This adds a `dateFormat` helper that works like this :
```
{{dateFormat '2022-02-01' 'YYYY'}}
```

And output :
```
2022
```

**Checklist**

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
