### PR TITLE
Fix data buckets containing request helpers being generated twice

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1082,14 +1082,15 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       const results = response.body?.matchAll(
         new RegExp('{{2,3}[\\s|#|\\w|(]*data [\'|"]{1}([^(\'|")]*)', 'g')
       );
-      const databucketIdsToParse = [...(results || [])].map(
-        (match) => match[1]
+      const databucketIdsToParse = new Set(
+        [...(results || [])].map((match) => match[1])
       );
+
       if (response.databucketID) {
-        databucketIdsToParse.push(response.databucketID);
+        databucketIdsToParse.add(response.databucketID);
       }
 
-      if (databucketIdsToParse.length) {
+      if (databucketIdsToParse.size > 0) {
         let targetDatabucket: ProcessedDatabucket | undefined;
 
         for (const databucketIdToParse of databucketIdsToParse) {


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
