### PR TITLE
Add "status" request helper

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -531,6 +531,13 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         );
       }
 
+      if (request.locals) {
+        const statusCode = request.locals.get('statusCode');
+        if (statusCode) {
+          response.status(statusCode);
+        }
+      }
+
       response.body = content;
 
       response.send(content);

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -633,6 +633,13 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               request
             );
 
+            if (request.locals) {
+              const statusCode = request.locals.get('statusCode');
+              if (statusCode) {
+                response.status(statusCode);
+              }
+            }
+
             response.body = fileContent;
             response.send(fileContent);
           } catch (error: any) {

--- a/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
@@ -83,7 +83,11 @@ export const DataHelpers = function (
 
         // ensure a value was found at path
         const foundValue = objectGet(value, path);
-        value = foundValue !== undefined ? foundValue : value;
+        if (parameters.length > 1 && parameters[2]) {
+          value = foundValue !== undefined ? foundValue : '';
+        } else {
+          value = foundValue !== undefined ? foundValue : value;
+        }
 
         return value;
       }

--- a/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
@@ -27,7 +27,9 @@ export const RequestHelpers = function (
     // set status code
     status: function (status: any) {
       const intCode = parseInt(status, 10);
-      if (isNaN(intCode)) return;
+      if (isNaN(intCode)) {
+        return;
+      }
       if (!request.locals) {
         request.locals = new Map<string, any>();
       }

--- a/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
@@ -24,6 +24,15 @@ export const RequestHelpers = function (
   environment: Environment
 ) {
   return {
+    // set status code
+    status: function (status: any) {
+      const intCode = parseInt(status, 10);
+      if (isNaN(intCode)) return;
+      if (!request.locals) {
+        request.locals = new Map<string, any>();
+      }
+      request.locals.set('statusCode', intCode);
+    },
     // get json property from body
     body: function (
       path: string | string[] | null,

--- a/packages/commons-server/src/typings.d.ts
+++ b/packages/commons-server/src/typings.d.ts
@@ -5,6 +5,7 @@ declare namespace Express {
     body: any;
     rawBody: Buffer;
     stringBody: string;
+    locals: Map<string, any>;
   }
   export interface Response {
     body: any;

--- a/packages/commons-server/test/suites/templating-helpers/data-helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/data-helpers.spec.ts
@@ -401,6 +401,50 @@ describe('Data helpers', () => {
       expect(parseResult).to.be.equal('value1');
     });
 
+    it('should return empty string if property does not exist', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{dataRaw 'pathDatabucket' 'object1.prop3' true}}",
+        {} as any,
+        [
+          {
+            name: 'pathDatabucket',
+            id: 'w63q',
+            value: {
+              object1: { prop1: 'value1', prop2: 'value2' },
+              prop: 'value',
+              object2: []
+            },
+            parsed: true
+          }
+        ],
+        {} as any
+      );
+      expect(parseResult).to.be.equal('');
+    });
+
+    it('should return entire content if null condition is false and property does not exist', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{dataRaw 'pathDatabucket' 'object1.prop3' false}}",
+        {} as any,
+        [
+          {
+            name: 'pathDatabucket',
+            id: 'w63q',
+            value: {
+              object1: { prop1: 'value1', prop2: 'value2' },
+              prop: 'value',
+              object2: []
+            },
+            parsed: true
+          }
+        ],
+        {} as any
+      );
+      expect(parseResult).not.to.be.equal('');
+    });
+
     it('should return falsy property at a path', () => {
       const parseResult = TemplateParser(
         false,

--- a/packages/commons-server/test/suites/templating-helpers/request-helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/request-helpers.spec.ts
@@ -12,6 +12,10 @@ const requestMock = {
   }
 } as any;
 
+beforeEach(function () {
+  delete requestMock.locals;
+});
+
 describe('Template parser', () => {
   describe('Helper: body', () => {
     it('should return number without quotes', () => {
@@ -727,6 +731,41 @@ describe('Template parser', () => {
         requestMock
       );
       expect(parseResult).to.be.equal('defaultvalue');
+    });
+  });
+
+  describe('Helper: status', () => {
+    it('should return request status undefined', () => {
+      const parseResult = TemplateParser(
+        false,
+        'Hello',
+        {} as any,
+        [],
+        requestMock
+      );
+      expect(requestMock.locals).to.be.undefined;
+    });
+
+    it('should return request status 404', () => {
+      const parseResult = TemplateParser(
+        false,
+        '{{status 404}}',
+        {} as any,
+        [],
+        requestMock
+      );
+      expect(requestMock.locals.get('statusCode')).to.be.equal(404);
+    });
+
+    it('should return request status 404 if condition is false', () => {
+      const parseResult = TemplateParser(
+        false,
+        '{{#if (eq 1 0)}}{{status 404}}{{else}}Hello{{/if}}',
+        {} as any,
+        [],
+        requestMock
+      );
+      expect(requestMock.locals).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
**Technical implementation details**

I want to propose this new helper. The impact is very little and it is simple to be used, but can be very useful in many cases.
The idea is to be able to set the response status inside the template.

Imagine a route like this:

    test/:id

and a data bucket with name `testdata` and the following content:

```
{
  "data": {
    "001": {
      "id": "001",
      "name": "Item 1"
    },
    "002": {
      "id": "002",
      "name": "Item 2"
    }
  }
}
```

now using a template like this:

```handlebar
{{setVar 'selection' (concat 'data.' (urlParam 'id'))}}
{{#if (dataRaw 'testdata' @selection true)}}
{{data 'testdata' @selection}}
{{else}}
{{status 404}}
{
  "error": "NOT_EXISTS"
}
{{/if}}
```

we have a routes where we can return 200 with data if the data exists in the bucket

    GET /test/001

or 404 if the data does not exist.

    GET /test/003

To be able to check the path selection I've also added an optional flag on `dataRaw` helper, that return an empty string `""` when the selection path does not match any property.

*If you accept this proposal I can finish it with tests and docs :P*

**Checklist**

<!-- Check relevant boxes -->

- [x] data migration added (@mockoon/commons)
- [x] data migration automated tests added (@mockoon/commons)
- [x] CLI automated tests added (@mockoon/cli)
- [x] desktop automated tests added (@mockoon/desktop)
