### PR TITLE
ipv4/ipv6 listening

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -134,7 +134,7 @@ OPTIONS
   -d, --data              [required] Path(s) or URL(s) to your Mockoon file(s)
   -N, --pname             Override process(es) name(s)
   -p, --port              Override environment(s) port(s)
-  -l, --hostname=0.0.0.0  Override default listening hostname(s) (0.0.0.0)
+  -l, --hostname          Override default listening hostname(s)
   -t, --log-transaction   Log the full HTTP transaction (request and response)
   -r, --repair            If the data file seems too old, or an invalid Mockoon file, migrate/repair without prompting
   -D, --daemon-off        Keep the CLI in the foreground and do not manage the process with PM2
@@ -142,7 +142,7 @@ OPTIONS
 
 EXAMPLES
   $ mockoon-cli start --data ~/data.json
-  $ mockoon-cli start --data ~/data1.json ~/data2.json --port 3000 3001 --pname mock1 mock2
+  $ mockoon-cli start --data ~/data1.json ~/data2.json --port 3000 3001 --pname mock1 mock2 --hostname 127.0.0.1 192.168.1.1
   $ mockoon-cli start --data https://file-server/data.json
   $ mockoon-cli start --data ~/data.json --pname "proc1"
   $ mockoon-cli start --data ~/data.json --daemon-off

--- a/packages/cli/docker/Dockerfile
+++ b/packages/cli/docker/Dockerfile
@@ -10,6 +10,6 @@ USER mockoon
 
 EXPOSE 3000
 
-ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off"]
+ENTRYPOINT ["mockoon-cli", "start", "--daemon-off"]
 
 # Usage: docker run --mount type=bind,source="$(pwd)"/dataFile.json,target=/data,readonly -p <port>:<port> mockoon-test -d data

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -40,7 +40,7 @@ export default class Start extends Command {
 
   public static examples = [
     '$ mockoon-cli start --data ~/data.json',
-    '$ mockoon-cli start --data ~/data1.json ~/data2.json --port 3000 3001 --pname mock1 mock2',
+    '$ mockoon-cli start --data ~/data1.json ~/data2.json --port 3000 3001 --pname mock1 mock2 --hostname 127.0.0.1 192.168.1.1',
     '$ mockoon-cli start --data https://file-server/data.json',
     '$ mockoon-cli start --data ~/data.json --pname "proc1"',
     '$ mockoon-cli start --data ~/data.json --daemon-off',
@@ -138,10 +138,9 @@ export default class Start extends Command {
   }
 
   private logStartedProcess(environmentInfo: EnvironmentInfo, process: Proc) {
-    const hostname =
-      environmentInfo.hostname === '0.0.0.0'
-        ? 'localhost'
-        : environmentInfo.hostname;
+    const hostname = !environmentInfo.hostname
+      ? 'localhost'
+      : environmentInfo.hostname;
 
     this.log(
       Messages.CLI.PROCESS_STARTED,

--- a/packages/cli/src/constants/docker.constants.ts
+++ b/packages/cli/src/constants/docker.constants.ts
@@ -14,6 +14,6 @@ USER mockoon
 
 EXPOSE{{#ports}} {{.}}{{/ports}}
 
-ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", {{#filePaths}}"{{.}}", {{/filePaths}}"--container"{{{args}}}]
+ENTRYPOINT ["mockoon-cli", "start", "--daemon-off", "--data", {{#filePaths}}"{{.}}", {{/filePaths}}"--container"{{{args}}}]
 
 # Usage: docker run -p <host_port>:<container_port> mockoon-test`;

--- a/packages/cli/test/data/envs/file.json
+++ b/packages/cli/test/data/envs/file.json
@@ -1,11 +1,11 @@
 {
   "uuid": "6cca9fb6-3585-4c0f-8cac-1150ce24452b",
   "name": "Environment file",
-  "lastMigration": 25,
+  "lastMigration": 27,
   "port": 3000,
   "endpointPrefix": "",
   "latency": 0,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "routes": [
     {
       "uuid": "e15f2c20-92aa-4390-8f83-2da2473b47ee",
@@ -32,7 +32,8 @@
         }
       ],
       "enabled": true,
-      "responseMode": null
+      "responseMode": null,
+      "type": "http"
     }
   ],
   "proxyMode": false,

--- a/packages/cli/test/data/envs/mock1.json
+++ b/packages/cli/test/data/envs/mock1.json
@@ -1,6 +1,6 @@
 {
   "uuid": "70d8639e-ef20-4d52-9749-c47d9ffc5c67",
-  "lastMigration": 25,
+  "lastMigration": 27,
   "name": "mock1",
   "endpointPrefix": "api",
   "latency": 0,
@@ -36,7 +36,8 @@
         }
       ],
       "enabled": true,
-      "responseMode": null
+      "responseMode": null,
+      "type": "http"
     }
   ],
   "proxyMode": false,
@@ -51,7 +52,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/cli/test/data/envs/mock2.json
+++ b/packages/cli/test/data/envs/mock2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "66f5a033-0d8b-4bc6-b5f9-a949d8fd0ec2",
-  "lastMigration": 25,
+  "lastMigration": 27,
   "name": "mock2",
   "endpointPrefix": "api",
   "latency": 0,
@@ -36,7 +36,8 @@
         }
       ],
       "enabled": true,
-      "responseMode": null
+      "responseMode": null,
+      "type": "http"
     }
   ],
   "proxyMode": false,
@@ -61,7 +62,7 @@
     }
   ],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/cli/test/data/envs/mock3.json
+++ b/packages/cli/test/data/envs/mock3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "f4c8cd6e-dbf4-4865-9558-08195ef8b36b",
-  "lastMigration": 25,
+  "lastMigration": 27,
   "name": "mock1",
   "endpointPrefix": "api",
   "latency": 0,
@@ -36,7 +36,8 @@
         }
       ],
       "enabled": true,
-      "responseMode": null
+      "responseMode": null,
+      "type": "http"
     }
   ],
   "proxyMode": false,
@@ -61,7 +62,7 @@
     }
   ],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/cli/test/data/envs/mock4.json
+++ b/packages/cli/test/data/envs/mock4.json
@@ -1,6 +1,6 @@
 {
   "uuid": "5d004e2c-6055-41bc-b0ac-4d0c064dddd1",
-  "lastMigration": 25,
+  "lastMigration": 27,
   "name": "mockhttps",
   "endpointPrefix": "api",
   "latency": 0,
@@ -28,7 +28,7 @@
     }
   ],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/cli/test/data/envs/repair.json
+++ b/packages/cli/test/data/envs/repair.json
@@ -4,7 +4,7 @@
   "port": 3000,
   "endpointPrefix": "",
   "latency": 0,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "routes": [
     {
       "uuid": "62088a1b-43da-4251-9420-b83b8bf9ede0",

--- a/packages/cli/test/data/envs/wrong-cert.json
+++ b/packages/cli/test/data/envs/wrong-cert.json
@@ -1,11 +1,11 @@
 {
   "uuid": "06d4e2f2-b7a1-4717-a61d-94666816c30f",
-  "lastMigration": 22,
+  "lastMigration": 27,
   "name": "test",
   "endpointPrefix": "",
   "latency": 0,
   "port": 3000,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "routes": [],
   "proxyMode": false,
   "proxyHost": "",
@@ -20,6 +20,8 @@
     "passphrase": ""
   },
   "cors": true,
+  "data": [],
+  "folders": [],
   "headers": [],
   "proxyReqHeaders": [],
   "proxyResHeaders": []

--- a/packages/cli/test/specs/dockerize-command.spec.ts
+++ b/packages/cli/test/specs/dockerize-command.spec.ts
@@ -43,7 +43,7 @@ describe('Dockerize command', () => {
           'COPY mockoon-mock1.json ./mockoon-mock1.json'
         );
         expect(dockerfileContent).to.contain(
-          'ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", "mockoon-mock1.json", "--container"]'
+          'ENTRYPOINT ["mockoon-cli", "start", "--daemon-off", "--data", "mockoon-mock1.json", "--container"]'
         );
         expect(dockerfileContent).to.contain('EXPOSE 3010');
       }
@@ -104,7 +104,7 @@ describe('Dockerize command', () => {
           'COPY mockoon-mock2.json ./mockoon-mock2.json'
         );
         expect(dockerfileContent).to.contain(
-          'ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", "mockoon-mock1.json", "mockoon-mock2.json", "--container"]'
+          'ENTRYPOINT ["mockoon-cli", "start", "--daemon-off", "--data", "mockoon-mock1.json", "mockoon-mock2.json", "--container"]'
         );
         expect(dockerfileContent).to.contain('EXPOSE 3010 3011');
       }

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -124,8 +124,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     });
 
     this.serverInstance.listen(
-      this.environment.port,
-      this.environment.hostname,
+      { port: this.environment.port, host: this.environment.hostname },
       () => {
         this.emit('started');
       }

--- a/packages/commons-server/test/data/environments/test-env.json
+++ b/packages/commons-server/test/data/environments/test-env.json
@@ -1,9 +1,9 @@
 {
   "uuid": "c6199444-5116-490a-99a2-074876253a4a",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Test env",
   "port": 3000,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "endpointPrefix": "",
   "latency": 0,
   "routes": [

--- a/packages/commons/src/constants/environment-schema.constants.ts
+++ b/packages/commons/src/constants/environment-schema.constants.ts
@@ -28,7 +28,7 @@ export const EnvironmentDefault: Environment = {
   endpointPrefix: '',
   latency: 0,
   port: 3000,
-  hostname: '0.0.0.0',
+  hostname: '',
   folders: [],
   routes: [],
   rootChildren: [],
@@ -322,7 +322,10 @@ export const EnvironmentSchema = Joi.object<Environment, true>({
     .max(65535)
     .failover(EnvironmentDefault.port)
     .required(),
-  hostname: Joi.string().failover(EnvironmentDefault.hostname).required(),
+  hostname: Joi.string()
+    .allow('')
+    .failover(EnvironmentDefault.hostname)
+    .required(),
   rootChildren: Joi.array()
     .items(FolderChildSchema, Joi.any().strip())
     .failover(EnvironmentDefault.rootChildren)

--- a/packages/commons/src/libs/migrations.ts
+++ b/packages/commons/src/libs/migrations.ts
@@ -527,6 +527,17 @@ export const Migrations: {
         }
       });
     }
+  },
+  /**
+   * Environment hostname default to null
+   */
+  {
+    id: 27,
+    migrationFunction: (environment: Environment) => {
+      if (environment.hostname === '0.0.0.0') {
+        environment.hostname = EnvironmentDefault.hostname;
+      }
+    }
   }
 ];
 

--- a/packages/commons/test/migrations.spec.ts
+++ b/packages/commons/test/migrations.spec.ts
@@ -327,4 +327,17 @@ describe('Migrations', () => {
       expect(environment.routes[1]['type']).to.equal(RouteDefault.type);
     });
   });
+
+  describe('migration n. 27', () => {
+    it('should set hostname to null by default', () => {
+      const environment1 = { hostname: '0.0.0.0' };
+      const environment2 = { hostname: '127.0.0.1' };
+
+      applyMigration(27, environment1);
+      applyMigration(27, environment2);
+
+      expect(environment1.hostname).to.equal('');
+      expect(environment2.hostname).to.equal('127.0.0.1');
+    });
+  });
 });

--- a/packages/desktop/src/renderer/app/components/environment-settings/environment-settings.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-settings/environment-settings.component.html
@@ -18,16 +18,23 @@
   <app-title-separator
     heading="API URL"
     icon="power"
-    subheading="API available on {{ activeEnvironment?.hostname }}:{{
-      activeEnvironment?.port
-    }}/{{ activeEnvironment?.endpointPrefix }}"
+    subheading="API available on {{
+      activeEnvironment?.hostname || 'localhost'
+    }}:{{ activeEnvironment?.port }}/{{ activeEnvironment?.endpointPrefix }}"
   ></app-title-separator>
 
   <div class="form-group">
     <div class="input-group">
-      <label for="env-settings-port" class="col-form-label pr-2">
-        {{ activeEnvironment?.hostname }} :</label
-      >
+      <input
+        type="text"
+        class="form-control col-1"
+        id="env-settings-hostname"
+        placeholder="localhost"
+        formControlName="hostname"
+      />
+      <div class="input-group-prepend">
+        <span class="input-group-text font-bold">:</span>
+      </div>
       <input
         type="number"
         class="form-control col-1"
@@ -50,27 +57,11 @@
         appValidPath
         formControlName="endpointPrefix"
       />
-    </div>
-  </div>
-
-  <div class="form-group">
-    <div class="input-group">
-      <div class="custom-control custom-checkbox">
-        <input
-          type="checkbox"
-          class="custom-control-input"
-          id="env-settings-localhost-only"
-          formControlName="localhostOnly"
-        />
-        <label class="custom-control-label" for="env-settings-localhost-only"
-          >Localhost Only
-        </label>
-      </div>
-      <div class="input-group-append ml-1">
+      <div class="input-group-append align-items-center ml-1">
         <app-svg
           icon="info"
           class="ml-1"
-          ngbTooltip="Listen to 127.0.0.1 only instead of all network adapters"
+          ngbTooltip="Default hostname is :: (IPv6) and 0.0.0.0 (IPv4)"
         ></app-svg>
       </div>
     </div>

--- a/packages/desktop/src/renderer/app/components/environment-settings/environment-settings.component.ts
+++ b/packages/desktop/src/renderer/app/components/environment-settings/environment-settings.component.ts
@@ -94,11 +94,11 @@ export class EnvironmentSettingsComponent implements OnInit, OnDestroy {
 
     this.activeEnvironmentForm = this.formBuilder.group({
       name: [EnvironmentDefault.name],
+      hostname: [EnvironmentDefault.hostname],
       port: [EnvironmentDefault.port],
       endpointPrefix: [EnvironmentDefault.endpointPrefix],
       latency: [EnvironmentDefault.latency],
       tlsOptions: this.tlsOptionsFormGroup,
-      localhostOnly: [false],
       cors: [EnvironmentDefault.cors]
     });
 
@@ -106,17 +106,9 @@ export class EnvironmentSettingsComponent implements OnInit, OnDestroy {
     merge(
       ...Object.keys(this.activeEnvironmentForm.controls).map((controlName) =>
         this.activeEnvironmentForm.get(controlName).valueChanges.pipe(
-          map((newValue) => {
-            if (controlName === 'localhostOnly') {
-              return {
-                hostname: newValue === true ? '127.0.0.1' : '0.0.0.0'
-              };
-            }
-
-            return {
-              [controlName]: newValue
-            };
-          })
+          map((newValue) => ({
+            [controlName]: newValue
+          }))
         )
       )
     )
@@ -142,11 +134,11 @@ export class EnvironmentSettingsComponent implements OnInit, OnDestroy {
           this.activeEnvironmentForm.setValue(
             {
               name: activeEnvironment.name,
+              hostname: activeEnvironment.hostname,
               port: activeEnvironment.port,
               endpointPrefix: activeEnvironment.endpointPrefix,
               latency: activeEnvironment.latency,
               tlsOptions: activeEnvironment.tlsOptions,
-              localhostOnly: activeEnvironment.hostname === '127.0.0.1',
               cors: activeEnvironment.cors
             },
             { emitEvent: false }

--- a/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
+++ b/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
@@ -96,9 +96,9 @@
                     ngbTooltip="TLS enabled"
                   ></app-svg>
                   <span
-                    >{{ environment.hostname }}:{{ environment.port }}/{{
-                      environment.endpointPrefix
-                    }}</span
+                    >{{ environment.hostname || 'localhost' }}:{{
+                      environment.port
+                    }}/{{ environment.endpointPrefix }}</span
                   >
                 </div>
               </div>

--- a/packages/desktop/src/renderer/app/components/modals/duplicate-modal/duplicate-modal.component.html
+++ b/packages/desktop/src/renderer/app/components/modals/duplicate-modal/duplicate-modal.component.html
@@ -27,7 +27,7 @@
         >
           <div class="ellipsis">{{ environment.name }}</div>
           <div class="nav-link-subtitle ellipsis">
-            {{ environment.hostname }}:{{ environment.port }}/{{
+            {{ environment.hostname || 'localhost' }}:{{ environment.port }}/{{
               environment.endpointPrefix
             }}
           </div>

--- a/packages/desktop/test/data/mock-envs/basic-data.json
+++ b/packages/desktop/test/data/mock-envs/basic-data.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Basic data",
   "endpointPrefix": "",
   "latency": 0,
@@ -98,7 +98,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/clipboard-copy.json
+++ b/packages/desktop/test/data/mock-envs/clipboard-copy.json
@@ -1,6 +1,6 @@
 {
   "uuid": "64fcbac0-1ac7-11ea-b8fd-577fb167a4ce",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Env clipboard copy",
   "endpointPrefix": "",
   "latency": 0,
@@ -42,7 +42,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/compression.json
+++ b/packages/desktop/test/data/mock-envs/compression.json
@@ -1,6 +1,6 @@
 {
   "uuid": "f98d0d37-b586-4a57-bbe5-3699bc46ebbe",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Compression (proxy)",
   "endpointPrefix": "",
   "latency": 0,
@@ -13,7 +13,7 @@
   "headers": [{ "key": "Content-Type", "value": "application/json" }],
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/crud.json
+++ b/packages/desktop/test/data/mock-envs/crud.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "CRUD",
   "endpointPrefix": "",
   "latency": 0,
@@ -98,7 +98,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/data-storage.json
+++ b/packages/desktop/test/data/mock-envs/data-storage.json
@@ -1,6 +1,6 @@
 {
   "uuid": "6d67bab2-886e-4635-9f9b-8bc1983c49c0",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -13,7 +13,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/databuckets.json
+++ b/packages/desktop/test/data/mock-envs/databuckets.json
@@ -1,6 +1,6 @@
 {
   "uuid": "5dd5c15a-d860-40da-83f4-7606e2c0ee22",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "databuckets",
   "endpointPrefix": "",
   "latency": 0,
@@ -98,7 +98,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/documentation.json
+++ b/packages/desktop/test/data/mock-envs/documentation.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a7186111-8f6f-45f0-aeb0-75fe40892d31",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Demo API",
   "endpointPrefix": "",
   "latency": 0,
@@ -179,7 +179,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/empty.json
+++ b/packages/desktop/test/data/mock-envs/empty.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Empty",
   "endpointPrefix": "",
   "latency": 0,
@@ -13,7 +13,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/headers.json
+++ b/packages/desktop/test/data/mock-envs/headers.json
@@ -1,6 +1,6 @@
 {
   "uuid": "5867a05a-fa89-4a4e-9116-8743188a1c07",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -126,7 +126,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/logs-1.json
+++ b/packages/desktop/test/data/mock-envs/logs-1.json
@@ -1,6 +1,6 @@
 {
   "uuid": "29d99394-91e4-4fbb-86c2-26b5f54abff7",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Environment logs 1",
   "endpointPrefix": "prefix",
   "latency": 0,
@@ -115,7 +115,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/logs-2.json
+++ b/packages/desktop/test/data/mock-envs/logs-2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "5f5ec26d-9a10-4b34-95a8-a9e4dff5ca41",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Environment logs 2",
   "endpointPrefix": "prefix",
   "latency": 0,
@@ -45,7 +45,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/openapi.json
+++ b/packages/desktop/test/data/mock-envs/openapi.json
@@ -1,6 +1,6 @@
 {
   "uuid": "e84c9920-6047-11ea-b4a3-058bbf68d234",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Demo users API V2",
   "endpointPrefix": "v2",
   "latency": 0,
@@ -234,7 +234,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/proxy-1.json
+++ b/packages/desktop/test/data/mock-envs/proxy-1.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -48,7 +48,7 @@
   "headers": [],
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/proxy-2.json
+++ b/packages/desktop/test/data/mock-envs/proxy-2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "2cbdec80-f284-11e9-a28c-912bdc671019",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Proxy",
   "endpointPrefix": "",
   "latency": 0,
@@ -13,7 +13,7 @@
   "headers": [{ "key": "Content-Type", "value": "application/json" }],
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/proxy-3.json
+++ b/packages/desktop/test/data/mock-envs/proxy-3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "53bce436-ee1d-461f-baf8-a837612faf38",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Proxy disabled",
   "endpointPrefix": "",
   "latency": 0,
@@ -44,7 +44,7 @@
   "proxyResHeaders": [
     { "key": "x-proxy-response-header", "value": "header value" }
   ],
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/proxy-4.json
+++ b/packages/desktop/test/data/mock-envs/proxy-4.json
@@ -1,6 +1,6 @@
 {
   "uuid": "2cbdec80-f284-11e9-a28c-912bdc671020",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Proxy removes prefix",
   "endpointPrefix": "prefix",
   "latency": 0,
@@ -13,7 +13,7 @@
   "headers": [{ "key": "Content-Type", "value": "application/json" }],
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/response-rules.json
+++ b/packages/desktop/test/data/mock-envs/response-rules.json
@@ -1,6 +1,6 @@
 {
   "uuid": "321179b8-861b-4c62-ad5f-b4b0adc8858a",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -736,7 +736,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/schema-uuid-dedup-1.json
+++ b/packages/desktop/test/data/mock-envs/schema-uuid-dedup-1.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a93e9c88-62f9-40a7-be4f-9645e1988d8a",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "uuid dedup 1",
   "endpointPrefix": "",
   "latency": 0,
@@ -42,7 +42,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/schema-uuid-dedup-2.json
+++ b/packages/desktop/test/data/mock-envs/schema-uuid-dedup-2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a93e9c88-62f9-40a7-be4f-9645e1988d8a",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "uuid dedup 2",
   "endpointPrefix": "",
   "latency": 0,
@@ -42,7 +42,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/schema-uuid-dedup-3.json
+++ b/packages/desktop/test/data/mock-envs/schema-uuid-dedup-3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a93e9c88-62f9-40a7-be4f-9645e1988d8a",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "uuid dedup load",
   "endpointPrefix": "",
   "latency": 0,
@@ -70,7 +70,7 @@
   "proxyReqHeaders": [],
   "proxyResHeaders": [],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/settings-env.json
+++ b/packages/desktop/test/data/mock-envs/settings-env.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -70,7 +70,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/templating.json
+++ b/packages/desktop/test/data/mock-envs/templating.json
@@ -1,6 +1,6 @@
 {
   "uuid": "0119ee98-f608-4a6e-909f-d6700d1c196b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "FT env",
   "endpointPrefix": "",
   "latency": 0,
@@ -1641,7 +1641,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/ui-1.json
+++ b/packages/desktop/test/data/mock-envs/ui-1.json
@@ -1,6 +1,6 @@
 {
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "UI env",
   "endpointPrefix": "",
   "latency": 0,
@@ -98,7 +98,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/mock-envs/ui-2.json
+++ b/packages/desktop/test/data/mock-envs/ui-2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "9ca3284a-d5e8-42a4-b3dc-cd74a304c764",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "UI env name edit",
   "endpointPrefix": "",
   "latency": 0,
@@ -13,7 +13,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": true,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/aws-cloudfront-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/aws-cloudfront-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "3e16e1a0-a802-11eb-9a34-f1c6ade0819b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Amazon CloudFront",
   "endpointPrefix": "",
   "latency": 0,
@@ -4759,7 +4759,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/aws-server-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/aws-server-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "00c259b0-a802-11eb-8344-e578768b170e",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "AWS Server Migration Service",
   "endpointPrefix": "",
   "latency": 0,
@@ -3059,7 +3059,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/custom-schema-no-prefix-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/custom-schema-no-prefix-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a03a4dc0-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Sample v2 schema",
   "endpointPrefix": "",
   "latency": 0,
@@ -42,7 +42,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/custom-schema-no-prefix-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/custom-schema-no-prefix-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a0d62338-24ce-4ced-bc97-59bf933d1ce9",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Sample v3 schema",
   "endpointPrefix": "",
   "latency": 0,
@@ -103,7 +103,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/custom-schema-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/custom-schema-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a03a4dc0-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Sample v2 schema",
   "endpointPrefix": "api",
   "latency": 0,
@@ -42,7 +42,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/custom-schema-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/custom-schema-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "61d19605-d609-4497-a951-0a2739409f88",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Sample v3 schema",
   "endpointPrefix": "api",
   "latency": 0,
@@ -103,7 +103,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/datagov-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/datagov-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "b8701e60-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Regulations.gov",
   "endpointPrefix": "regulations/v3",
   "latency": 0,
@@ -200,7 +200,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/giphy-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/giphy-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "d1fec840-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Giphy",
   "endpointPrefix": "v1",
   "latency": 0,
@@ -974,7 +974,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/github-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/github-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "db17bb30-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "GitHub",
   "endpointPrefix": "",
   "latency": 0,
@@ -14698,7 +14698,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/petstore-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/petstore-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "5f2b78e0-fb9e-4318-b821-9c11acb79547",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Swagger Petstore v2",
   "endpointPrefix": "v2",
   "latency": 0,
@@ -850,7 +850,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/petstore-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/petstore-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "530c5c03-82c7-461d-a794-43a67bc5af0b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Swagger Petstore v3",
   "endpointPrefix": "v2",
   "latency": 0,
@@ -198,7 +198,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/shutterstock-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/shutterstock-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "f98d4710-e7d4-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Shutterstock API Explorer",
   "endpointPrefix": "",
   "latency": 0,
@@ -6403,7 +6403,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/slack-v2.json
+++ b/packages/desktop/test/data/res/import-openapi/references/slack-v2.json
@@ -1,6 +1,6 @@
 {
   "uuid": "83e373f4-63db-4d2b-8d84-f9fc8679c400",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "Slack",
   "endpointPrefix": "api",
   "latency": 0,
@@ -6954,7 +6954,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/data/res/import-openapi/references/youtube-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/youtube-v3.json
@@ -1,6 +1,6 @@
 {
   "uuid": "0c9cbbb0-e7d5-11ea-a5ec-979674ac1a4b",
-  "lastMigration": 26,
+  "lastMigration": 27,
   "name": "YouTube Analytics",
   "endpointPrefix": "",
   "latency": 0,
@@ -238,7 +238,7 @@
   "proxyReqHeaders": [{ "key": "", "value": "" }],
   "proxyResHeaders": [{ "key": "", "value": "" }],
   "proxyRemovePrefix": false,
-  "hostname": "0.0.0.0",
+  "hostname": "",
   "tlsOptions": {
     "enabled": false,
     "type": "CERT",

--- a/packages/desktop/test/libs/environments-settings.ts
+++ b/packages/desktop/test/libs/environments-settings.ts
@@ -2,14 +2,13 @@ import { ChainablePromiseElement } from 'webdriverio';
 import utils from '../libs/utils';
 
 type SettingNames =
-  | 'localhostOnly'
   | 'endpointPrefix'
   | 'name'
+  | 'hostname'
   | 'port'
   | 'certPath'
   | 'keyPath'
   | 'passphrase'
-  | 'localhostOnly'
   // enable tls formControlName
   | 'enabled';
 
@@ -21,12 +20,12 @@ class EnvironmentsSettings {
     return $('app-environment-settings #tls-cert-container');
   }
 
-  public get prefix(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $('app-environment-settings input[formcontrolname=endpointPrefix]');
+  public get hostname(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $('app-environment-settings input[formcontrolname=hostname]');
   }
 
-  public get localhostOnly(): ChainablePromiseElement<WebdriverIO.Element> {
-    return $('app-environment-settings label[for=env-settings-localhost-only]');
+  public get prefix(): ChainablePromiseElement<WebdriverIO.Element> {
+    return $('app-environment-settings input[formcontrolname=endpointPrefix]');
   }
 
   public get enableTLS(): ChainablePromiseElement<WebdriverIO.Element> {

--- a/packages/desktop/test/specs/databuckets.spec.ts
+++ b/packages/desktop/test/specs/databuckets.spec.ts
@@ -113,7 +113,7 @@ describe('Databucket duplication to another envionment', () => {
     expect(modalText).toContain('My Databucket');
 
     await modals.assertDuplicationModalEnvName('Basic data');
-    await modals.assertDuplicationModalEnvHostname('0.0.0.0:3000/');
+    await modals.assertDuplicationModalEnvHostname('localhost:3000/');
   });
 
   it('should duplicate the databucket in another env', async () => {

--- a/packages/desktop/test/specs/environment-hostname-restriction.spec.ts
+++ b/packages/desktop/test/specs/environment-hostname-restriction.spec.ts
@@ -51,7 +51,7 @@ describe('Environment hostname restriction', async () => {
   describe('Environment answers on localhost only', async () => {
     it('should switch to localhost only and start default environment', async () => {
       await navigation.switchView('ENV_SETTINGS');
-      await environmentsSettings.toggleSetting('localhostOnly');
+      await environmentsSettings.setSettingValue('hostname', '127.0.0.1');
       await environments.restart();
     });
 

--- a/packages/desktop/test/specs/external-changes-watcher.spec.ts
+++ b/packages/desktop/test/specs/external-changes-watcher.spec.ts
@@ -54,7 +54,7 @@ describe('Environment external reload', () => {
     await environments.assertMenuEntryText(
       1,
       'env 1 (change1)',
-      '0.0.0.0:5005'
+      'localhost:5005'
     );
 
     await navigation.assertHeaderValue('ENV_LOGS', 'Logs');

--- a/packages/desktop/test/specs/routes-duplicate-to-env.spec.ts
+++ b/packages/desktop/test/specs/routes-duplicate-to-env.spec.ts
@@ -38,7 +38,7 @@ describe('Duplicate a route to an environment', async () => {
     expect(targetRoute).toContain('POST /dolphins');
 
     await modals.assertDuplicationModalEnvName('New env test');
-    await modals.assertDuplicationModalEnvHostname('0.0.0.0:3001/');
+    await modals.assertDuplicationModalEnvHostname('localhost:3001/');
   });
 
   it('should duplicate selected route to selected environment', async () => {

--- a/packages/desktop/test/specs/templating.spec.ts
+++ b/packages/desktop/test/specs/templating.spec.ts
@@ -692,7 +692,7 @@ const testSuites: { name: string; tests: HttpCall[] }[] = [
         method: 'GET',
         testedResponse: {
           status: 200,
-          body: '127.0.0.1'
+          body: '::ffff:127.0.0.1'
         }
       },
       {

--- a/packages/desktop/test/tools/documentation.spec.ts
+++ b/packages/desktop/test/tools/documentation.spec.ts
@@ -605,16 +605,16 @@ const documentationTopics: {
       {
         tasks: async () => {
           await navigation.switchView('ENV_SETTINGS');
-          await environmentsSettings.toggleSetting('localhostOnly');
+          await environmentsSettings.setSettingValue('hostname', '192.168.1.1');
         },
         get highlightedTarget() {
-          return environmentsSettings.localhostOnly;
+          return environmentsSettings.hostname;
         },
         highlight: true,
-        highlightGaps: { top: 5, right: 10, bottom: 5, left: 30 },
+        highlightGaps: { top: 0, right: 0, bottom: 0, left: 0 },
         screenshotPosition: { top: 0, left: 0, right: 0 },
         screeenshotGaps: { bottom: 50 },
-        fileName: 'enable-localhost-only.png'
+        fileName: 'custom-hostname-setting.png'
       }
     ]
   },

--- a/packages/serverless/test/suites/serverless.spec.ts
+++ b/packages/serverless/test/suites/serverless.spec.ts
@@ -4,7 +4,7 @@ import { MockoonServerless } from '../../src';
 
 const mockEnvironment: Environment = {
   uuid: 'caa83503-bf21-41c6-b71f-8068fa6dd54d',
-  lastMigration: 25,
+  lastMigration: 27,
   name: 'Basic data',
   endpointPrefix: '',
   latency: 0,
@@ -17,7 +17,7 @@ const mockEnvironment: Environment = {
   proxyReqHeaders: [],
   proxyResHeaders: [],
   proxyRemovePrefix: false,
-  hostname: '0.0.0.0',
+  hostname: '',
   tlsOptions: {
     enabled: false,
     type: 'CERT',


### PR DESCRIPTION
Modify the environment hostname property to let Node.js handle the listening by default (ipv4 and v6, see https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten) and let the user provide a specific IP to listen to (same as the CLI).  Closes #930

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
