### PR TITLE
Adds skipIfNoRuleMatch to responses

### DIFF
--- a/packages/commons-server/src/libs/response-rules-interpreter.ts
+++ b/packages/commons-server/src/libs/response-rules-interpreter.ts
@@ -40,7 +40,7 @@ export class ResponseRulesInterpreter {
    * Choose the route response depending on the first fulfilled rule.
    * If no rule has been fulfilled get the first route response.
    */
-  public chooseResponse(requestNumber: number): RouteResponse {
+  public chooseResponse(requestNumber: number): RouteResponse | null {
     // if no rules were fulfilled find the default one, or first one if no default
     const defaultResponse =
       this.routeResponses.find((routeResponse) => routeResponse.default) ||
@@ -72,6 +72,10 @@ export class ResponseRulesInterpreter {
               this.isValid(rule, requestNumber)
             );
       });
+
+      if (response === undefined && defaultResponse.skipIfNoRuleMatch) {
+        return null;
+      }
 
       if (response === undefined) {
         response = defaultResponse;

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -435,7 +435,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     requestNumber: number,
     crudId?: CrudRouteIds
   ) {
-    return (request: Request, response: Response) => {
+    return (request: Request, response: Response, next: NextFunction) => {
       this.generateRequestDatabuckets(route, this.environment, request);
 
       // refresh environment data to get route changes that do not require a restart (headers, body, etc)
@@ -457,6 +457,10 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         request,
         currentRoute.responseMode
       ).chooseResponse(requestNumber);
+
+      if (!enabledRouteResponse) {
+        return next();
+      }
 
       requestNumber += 1;
 

--- a/packages/commons-server/test/suites/response-rules/response-rules-interpreter.spec.ts
+++ b/packages/commons-server/test/suites/response-rules/response-rules-interpreter.spec.ts
@@ -2855,4 +2855,132 @@ describe('Response rules interpreter', () => {
       expect(routeResponse.body).to.be.equal('content1');
     });
   });
+
+  describe('skip non matching routes', ()=>{
+
+
+    it('should return response if rules fulfilled and ignore the response marked as default', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = {
+            'Content-Type': 'application/json'
+          };
+
+          return headers[headerName];
+        },
+        stringBody: 'bodyvalue',
+        body: 'bodyvalue'
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          {
+            ...routeResponseTemplate,
+            body: 'content1',
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: 'bodyvalue',
+                operator: 'regex',
+                invert: false
+              }
+            ],
+            rulesOperator: 'OR',
+            default: true,
+            skipIfNoRuleMatch: true
+          },
+          { ...routeResponseTemplate, body: 'content2', default: true }
+        ],
+        request,
+        null,
+
+      ).chooseResponse(1);
+
+      expect(routeResponse.body).to.be.equal('content1');
+    });
+
+    it('should not return response if rules not fulfilled', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = {
+            'Content-Type': 'application/json'
+          };
+
+          return headers[headerName];
+        },
+        stringBody: 'not matching',
+        body: 'not matching'
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          {
+            ...routeResponseTemplate,
+            body: 'content1',
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: 'bodyvalue',
+                operator: 'regex',
+                invert: false
+              }
+            ],
+            rulesOperator: 'OR',
+            default: true,
+            skipIfNoRuleMatch: true
+          },
+          { ...routeResponseTemplate, body: 'content2', default: true }
+        ],
+        request,
+        null,
+
+      ).chooseResponse(1);
+
+      expect(routeResponse).to.be.null;
+    });
+
+    it('should return default response if not default is marked as skip', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = {
+            'Content-Type': 'application/json'
+          };
+
+          return headers[headerName];
+        },
+        stringBody: 'not matching',
+        body: 'not matching'
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          {
+            ...routeResponseTemplate,
+            body: 'content1',
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: 'bodyvalue',
+                operator: 'regex',
+                invert: false
+              },
+            ],
+            rulesOperator: 'OR',
+            default: true,
+            skipIfNoRuleMatch: false
+          },
+          { ...routeResponseTemplate, body: 'content2', default: false, skipIfNoRuleMatch: true }
+        ],
+        request,
+        null,
+
+      ).chooseResponse(1);
+
+      expect(routeResponse.body).to.be.equal('content1');
+    });
+
+  });
 });

--- a/packages/commons/src/constants/environment-schema.constants.ts
+++ b/packages/commons/src/constants/environment-schema.constants.ts
@@ -69,6 +69,7 @@ export const RouteDefault: Route = {
   endpoint: '',
   responses: [],
   enabled: true,
+  skipIfNoRuleMatch: false,
   responseMode: null
 };
 
@@ -89,6 +90,7 @@ export const RouteResponseDefault: RouteResponse = {
   rulesOperator: 'OR',
   disableTemplating: false,
   fallbackTo404: false,
+  skipIfNoRuleMatch: false,
   default: false
 };
 
@@ -237,6 +239,9 @@ const RouteResponseSchema = Joi.object<RouteResponse, true>({
   fallbackTo404: Joi.boolean()
     .failover(RouteResponseDefault.fallbackTo404)
     .required(),
+  skipIfNoRuleMatch: Joi.boolean()
+    .default(RouteResponseDefault.skipIfNoRuleMatch)
+    .required(),
   default: Joi.boolean().failover(RouteResponseDefault.default).required()
 });
 
@@ -294,6 +299,9 @@ export const RouteSchema = Joi.object<Route, true>({
     .failover(RouteDefault.responses)
     .required(),
   enabled: Joi.boolean().failover(RouteDefault.enabled).required(),
+  skipIfNoRuleMatch: Joi.boolean()
+    .failover(RouteDefault.skipIfNoRuleMatch)
+    .required(),
   responseMode: Joi.string()
     .allow(null)
     .valid(

--- a/packages/commons/src/libs/migrations.ts
+++ b/packages/commons/src/libs/migrations.ts
@@ -540,6 +540,19 @@ export const Migrations: {
         environment.hostname = EnvironmentDefault.hostname;
       }
     }
+  },
+  /**
+   * default responses.skipIfNoRuleMatch to false
+   */
+  {
+    id: 28,
+    migrationFunction: (environment: Environment) => {
+      environment.routes.forEach((route: Route) => {
+        route.responses.forEach((response) => {
+          response.skipIfNoRuleMatch = false;
+        });
+      });
+    }
   }
 ];
 

--- a/packages/commons/src/models/route.model.ts
+++ b/packages/commons/src/models/route.model.ts
@@ -22,6 +22,7 @@ export type RouteResponse = {
   disableTemplating: boolean;
   fallbackTo404: boolean;
   default: boolean;
+  skipIfNoRuleMatch: boolean;
 };
 
 export enum ResponseMode {
@@ -66,6 +67,7 @@ export type Route = {
   endpoint: string;
   responses: RouteResponse[];
   enabled: boolean;
+  skipIfNoRuleMatch: boolean;
   responseMode: ResponseMode | null;
 };
 

--- a/packages/commons/test/migrations.spec.ts
+++ b/packages/commons/test/migrations.spec.ts
@@ -340,4 +340,17 @@ describe('Migrations', () => {
       expect(environment2.hostname).to.equal('127.0.0.1');
     });
   });
+
+  describe('migration n. 28', () => {
+    it('should set skipIfNoRuleMatch to false by default', () => {
+      const environment1 = { routes: [{ responses: [{}] }] };
+
+      applyMigration(28, environment1);
+
+      // @ts-ignore
+      expect(environment1.routes[0].responses[0].skipIfNoRuleMatch).to.equal(
+        false
+      );
+    });
+  });
 });

--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
@@ -663,6 +663,31 @@
                 </div>
               </div>
             </div>
+            <div class="form-group">
+              <div class="input-group">
+                <div class="custom-control custom-checkbox">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="route-settings-skip-if-no-rule-match"
+                    formControlName="skipIfNoRuleMatch"
+                    [disabled]='activeRouteResponse?.default'
+                  />
+                  <label
+                    class="custom-control-label"
+                    for="route-settings-skip-if-no-rule-match"
+                  >Skip route if rules don't match
+                  </label>
+                </div>
+                <div class="input-group-append ml-1">
+                  <app-svg
+                    icon="info"
+                    class="ml-1"
+                    ngbTooltip="Skips this whole route if the default response has this flagged and no rules match"
+                  ></app-svg>
+                </div>
+              </div>
+            </div>
           </div>
         </ng-container>
 

--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
@@ -525,7 +525,8 @@ export class EnvironmentRoutesComponent implements OnInit, OnDestroy {
       body: [RouteResponseDefault.body],
       rules: this.formBuilder.array([]),
       disableTemplating: [RouteResponseDefault.disableTemplating],
-      fallbackTo404: [RouteResponseDefault.fallbackTo404]
+      fallbackTo404: [RouteResponseDefault.fallbackTo404],
+      skipIfNoRuleMatch: [RouteResponseDefault.skipIfNoRuleMatch]
     });
 
     // send new activeRouteResponseForm values to the store, one by one


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

This PR is an alternative proposed solution for #363 (original pr #1068). This adds an extra setting called `skipIfNoRuleMatch` when this is enabled on the default response and the response is used as a default then the whole route is skipped. This is done using the express next method which triggers express to continue processing routes. If proxy mode is enabled this allows for proxying if rules for a route are not triggered.

**Checklist**

<!-- Check relevant boxes -->

- [x] data migration added (@mockoon/commons)
- [x] data migration automated tests added (@mockoon/commons)
- [x]commons-server tests added (@mockoon/commons-server)
