### PR TITLE
docs: cross platform disabling std logging

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -374,6 +374,11 @@ You can disable the logging to the console by redirecting the stdout and stderr 
   mockoon-cli start --data ./data.json > $null 2>&1
   ```
 
+- Cross platform: use `dev-null-cli` package
+  ```sh-sessions
+  mockoon-cli start --data ./data.json | npx dev-null
+  ```
+
 You can also disable file logging by using th `--disable-log-to-file` flag. This is enabled by default in the Docker image.
 
 ## Mockoon's documentation


### PR DESCRIPTION
May be useful for teams using multiple platforms (as we do).
Hopefully save somebody some time :)

https://github.com/mockoon/mockoon/issues/895