### PR TITLE
Add an "all" methods choice

### DIFF
--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
         "@faker-js/faker": "7.6.0",
-        "@mockoon/commons": "4.1.0",
         "append-field": "1.0.0",
         "busboy": "1.6.0",
         "cookie-parser": "1.4.6",
@@ -219,19 +218,6 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -270,17 +256,6 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "node_modules/@mockoon/commons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@mockoon/commons/-/commons-4.1.0.tgz",
-      "integrity": "sha512-bU7pLeoQS5F6xN8ANViudEHvxKIZCva7DOJHqL1QsJHutVMgfIx+ad6oSINuofyZ7EmDCk+jZsRpMGaCThM9bw==",
-      "dependencies": {
-        "joi": "17.8.3"
-      },
-      "funding": {
-        "url": "https://mockoon.com/sponsor-us/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -315,24 +290,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -2597,18 +2554,6 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
-    "node_modules/joi": {
-      "version": "17.8.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
-      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/js-sdsl": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
@@ -4500,19 +4445,6 @@
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
       "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw=="
     },
-    "@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -4541,14 +4473,6 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "@mockoon/commons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@mockoon/commons/-/commons-4.1.0.tgz",
-      "integrity": "sha512-bU7pLeoQS5F6xN8ANViudEHvxKIZCva7DOJHqL1QsJHutVMgfIx+ad6oSINuofyZ7EmDCk+jZsRpMGaCThM9bw==",
-      "requires": {
-        "joi": "17.8.3"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4574,24 +4498,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -6295,18 +6201,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
-    },
-    "joi": {
-      "version": "17.8.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.8.3.tgz",
-      "integrity": "sha512-q5Fn6Tj/jR8PfrLrx4fpGH4v9qM6o+vDUfD4/3vxxyg34OmKcNqYZ1qn2mpLza96S8tL0p0rIw2gOZX+/cTg9w==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
     },
     "js-sdsl": {
       "version": "4.4.2",

--- a/packages/commons/src/constants/environment-schema.constants.ts
+++ b/packages/commons/src/constants/environment-schema.constants.ts
@@ -273,6 +273,7 @@ export const RouteSchema = Joi.object<Route, true>({
   method: Joi.string()
     .allow('')
     .valid(
+      Methods.all,
       Methods.get,
       Methods.post,
       Methods.put,

--- a/packages/commons/src/models/route.model.ts
+++ b/packages/commons/src/models/route.model.ts
@@ -87,6 +87,7 @@ export type Route = {
 export type Header = { key: string; value: string };
 
 export enum Methods {
+  all = 'all',
   get = 'get',
   post = 'post',
   put = 'put',

--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
@@ -90,6 +90,11 @@ export class EnvironmentRoutesComponent implements OnInit, OnDestroy {
   public databuckets$: Observable<DropdownItems>;
   public methods: DropdownItems = [
     {
+      value: Methods.all,
+      label: 'All methods',
+      classes: 'route-badge-all-text'
+    },
+    {
       label: 'HTTP',
       category: true
     },

--- a/packages/desktop/src/renderer/styles/styles.scss
+++ b/packages/desktop/src/renderer/styles/styles.scss
@@ -122,10 +122,11 @@ input,
 }
 
 // route badges (methods)
-$route-badges: ('crud', lighten($cyan, 15%)), ('get', lighten($blue, 10%)),
-  ('put', lighten($orange, 10%)), ('post', lighten($green, 10%)),
-  ('delete', lighten($red, 17%)), ('head', lighten($purple, 25%)),
-  ('patch', $teal), ('options', lighten($dark-blue, 30%)),
+$route-badges: ('crud', lighten($cyan, 15%)), ('all', lighten($teal, 15%)),
+  ('get', lighten($blue, 10%)), ('put', lighten($orange, 10%)),
+  ('post', lighten($green, 10%)), ('delete', lighten($red, 17%)),
+  ('head', lighten($purple, 25%)), ('patch', $yellow),
+  ('options', lighten($dark-blue, 30%)),
   ('propfind', lighten($custom-gray, 45%)),
   ('proppatch', lighten($custom-gray, 45%)),
   ('copy', lighten($custom-gray, 45%)), ('move', lighten($custom-gray, 45%)),
@@ -141,10 +142,10 @@ $route-badges: ('crud', lighten($cyan, 15%)), ('get', lighten($blue, 10%)),
   }
 }
 
-// response badges (methods)
-$response-badges: ('get', lighten($blue, 10%)), ('4xx', lighten($orange, 10%)),
-  ('2xx', lighten($green, 10%)), ('5xx', lighten($red, 17%)),
-  ('3xx', lighten($purple, 25%)), ('1xx', lighten($custom-gray, 45%));
+// response badges (status codes)
+$response-badges: ('4xx', lighten($orange, 10%)), ('2xx', lighten($green, 10%)),
+  ('5xx', lighten($red, 17%)), ('3xx', lighten($purple, 25%)),
+  ('1xx', lighten($custom-gray, 45%));
 @each $status in $response-badges {
   .response-badge-#{nth($status, 1)} {
     background-color: #{nth($status, 2)};

--- a/packages/desktop/test/data/mock-envs/global-route.json
+++ b/packages/desktop/test/data/mock-envs/global-route.json
@@ -1,0 +1,153 @@
+{
+  "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
+  "lastMigration": 28,
+  "name": "Global route and rules",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "routes": [
+    {
+      "uuid": "9745a08e-94c2-451e-bccc-b31dc608bb6d",
+      "method": "all",
+      "endpoint": "*",
+      "documentation": "",
+      "enabled": true,
+      "responses": [
+        {
+          "uuid": "057ec98a-dd5d-4dd8-9af9-a99dd7a5c3f5",
+          "body": "unauthorized",
+          "latency": 0,
+          "statusCode": 403,
+          "label": "",
+          "headers": [],
+          "filePath": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "Authorization",
+              "value": "",
+              "invert": false,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "databucketID": "",
+          "bodyType": "INLINE",
+          "crudKey": "id"
+        }
+      ],
+      "responseMode": "FALLBACK",
+      "type": "http"
+    },
+    {
+      "uuid": "a80d01ac-a3ac-4551-9332-5d3aa1099569",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "test",
+      "responses": [
+        {
+          "uuid": "9a24ce9f-a5da-465d-9f58-1f624adf3e11",
+          "body": "okget",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id"
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "9e531525-6937-4e35-b6b7-0018c33a73bc",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "test",
+      "responses": [
+        {
+          "uuid": "8fa6166f-e25d-4e8b-b2d8-ee246bc689d8",
+          "body": "okpost",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id"
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "text/plain"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyRemovePrefix": false,
+  "hostname": "",
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "data": [],
+  "folders": [],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "9745a08e-94c2-451e-bccc-b31dc608bb6d"
+    },
+    {
+      "type": "route",
+      "uuid": "a80d01ac-a3ac-4551-9332-5d3aa1099569"
+    },
+    {
+      "type": "route",
+      "uuid": "9e531525-6937-4e35-b6b7-0018c33a73bc"
+    }
+  ]
+}

--- a/packages/desktop/test/specs/global-route.spec.ts
+++ b/packages/desktop/test/specs/global-route.spec.ts
@@ -1,0 +1,67 @@
+import environments from '../libs/environments';
+import http from '../libs/http';
+import { HttpCall } from '../libs/models';
+import routes from '../libs/routes';
+
+const testCases: HttpCall[] = [
+  {
+    description:
+      'should call the GET test endpoint without Authorization header and get the fallback route error',
+    path: '/test',
+    method: 'GET',
+    testedResponse: {
+      status: 403,
+      body: 'unauthorized'
+    }
+  },
+  {
+    description:
+      'should call the POST test endpoint without Authorization header and get the fallback route error',
+    path: '/test',
+    method: 'POST',
+    testedResponse: {
+      status: 403,
+      body: 'unauthorized'
+    }
+  },
+  {
+    description:
+      'should call the GET test endpoint with an Authorization header and get the route response',
+    path: '/test',
+    method: 'GET',
+    headers: { Authorization: 'Bearer abc' },
+    testedResponse: {
+      status: 200,
+      body: 'okget'
+    }
+  },
+  {
+    description:
+      'should call the POST test endpoint with an Authorization header and get the route response',
+    path: '/test',
+    method: 'POST',
+    headers: { Authorization: 'Bearer abc' },
+    testedResponse: {
+      status: 200,
+      body: 'okpost'
+    }
+  }
+];
+
+describe('Global routes and rules', () => {
+  it('should open and run the environment', async () => {
+    await environments.open('global-route');
+    await environments.start();
+  });
+
+  it('should verify the method displayed in the menu', async () => {
+    await routes.select(1);
+    await routes.assertMenuEntryText(1, 'ALL');
+  });
+
+  for (const testCase of testCases) {
+    it(testCase.description, async () => {
+      await http.assertCall(testCase);
+    });
+  }
+});

--- a/packages/desktop/test/specs/ui-interactions.spec.ts
+++ b/packages/desktop/test/specs/ui-interactions.spec.ts
@@ -253,7 +253,7 @@ describe('UI interactions', () => {
     it('should be able to select a method by clicking', async () => {
       await routes.select(1);
       await utils.openDropdown(dropdownId);
-      await utils.selectDropdownItem(dropdownId, 3);
+      await utils.selectDropdownItem(dropdownId, 4);
 
       await utils.waitForAutosave();
       await file.verifyObjectPropertyInFile(


### PR DESCRIPTION
Fallback mode already allows for global route with rules, but the possibility to use this global route on all methods is missing. Closes #221

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
