### PR TITLE
Fix menu sizes not being restored in desktop app

### DIFF
--- a/packages/desktop/src/main/libs/main-window.ts
+++ b/packages/desktop/src/main/libs/main-window.ts
@@ -66,6 +66,11 @@ export const initMainWindow = () => {
     }
   });
 
+  // maximize before showing the window to avoid a resize event on start (this may break the menu size setting restore)
+  if (mainWindowState.isMaximized) {
+    mainWindow.maximize();
+  }
+
   if (IS_DEV) {
     mainWindow.webContents.openDevTools();
   }


### PR DESCRIPTION
Rely on the window state to maximize before showing the BrowserWindow. This avoid jumping from a smaller size to a maximize state and reduce the size of the menus. Do not save the settings when restoring, but only after a resize event or a user interaction. Also improve performances by only saving after mouse up or resize event.

Closes #1167

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
