### PR TITLE
Simplify desktop app menu scroll to items

### DIFF
--- a/packages/desktop/src/renderer/app/app.module.ts
+++ b/packages/desktop/src/renderer/app/app.module.ts
@@ -60,6 +60,7 @@ import { DropzoneDirective } from 'src/renderer/app/directives/dropzone.directiv
 import { FocusOnEventDirective } from 'src/renderer/app/directives/focus-event.directive';
 import { InputNumberDirective } from 'src/renderer/app/directives/input-number.directive';
 import { ResizeColumnDirective } from 'src/renderer/app/directives/resize-column.directive';
+import { ScrollWhenActiveDirective } from 'src/renderer/app/directives/scroll-to-active.directive';
 import { SearchFilterDirective } from 'src/renderer/app/directives/search-filter.directive';
 import { ValidPathDirective } from 'src/renderer/app/directives/valid-path.directive';
 import { MarkedOptionsFactory } from 'src/renderer/app/modules-config/markdown.config';
@@ -84,6 +85,7 @@ import { AppComponent } from './app.component';
     DraggableDirective,
     DropzoneDirective,
     SearchFilterDirective,
+    ScrollWhenActiveDirective,
     ContextMenuComponent,
     CommandPaletteModalComponent,
     AuthModalComponent,

--- a/packages/desktop/src/renderer/app/components/menus/databuckets-menu/databuckets-menu.component.html
+++ b/packages/desktop/src/renderer/app/components/menus/databuckets-menu/databuckets-menu.component.html
@@ -43,10 +43,13 @@
     </div>
 
     <ng-container *ngIf="databucketList$ | async as databucketList">
-      <ul class="nav flex-column menu-list h-100" #databucketsMenu>
+      <ul class="nav flex-column menu-list h-100">
         <li
           class="nav-item"
-          *ngFor="let environmentDatabucket of databucketList"
+          *ngFor="
+            let environmentDatabucket of databucketList;
+            trackBy: trackByUuid
+          "
           [appSearchFilter]="databucketsFilter$"
           appDraggable
           appDropzone
@@ -63,6 +66,7 @@
               active:
                 (activeDatabucket$ | async)?.uuid === environmentDatabucket.uuid
             }"
+            appScrollWhenActive
             (click)="selectDatabucket(environmentDatabucket.uuid)"
             (contextmenu)="openContextMenu(environmentDatabucket.uuid, $event)"
           >

--- a/packages/desktop/src/renderer/app/components/menus/databuckets-menu/databuckets-menu.component.ts
+++ b/packages/desktop/src/renderer/app/components/menus/databuckets-menu/databuckets-menu.component.ts
@@ -1,15 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   HostListener,
   OnDestroy,
-  OnInit,
-  ViewChild
+  OnInit
 } from '@angular/core';
 import { FormBuilder, FormControl } from '@angular/forms';
 import { DataBucket, Environment } from '@mockoon/commons';
-import { from, Observable, Subject } from 'rxjs';
+import { Observable, Subject, from } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -21,6 +19,7 @@ import {
 import { DatabucketsContextMenu } from 'src/renderer/app/components/context-menu/context-menus';
 import { MainAPI } from 'src/renderer/app/constants/common.constants';
 import { FocusableInputs } from 'src/renderer/app/enums/ui.enum';
+import { trackByUuid } from 'src/renderer/app/libs/utils.lib';
 import { ContextMenuEvent } from 'src/renderer/app/models/context-menu.model';
 import {
   DraggableContainers,
@@ -28,7 +27,6 @@ import {
 } from 'src/renderer/app/models/ui.model';
 import { EnvironmentsService } from 'src/renderer/app/services/environments.service';
 import { EventsService } from 'src/renderer/app/services/events.service';
-import { UIService } from 'src/renderer/app/services/ui.service';
 import { updateFilterAction } from 'src/renderer/app/stores/actions';
 import { Store } from 'src/renderer/app/stores/store';
 import { Config } from 'src/renderer/config';
@@ -41,7 +39,6 @@ import { Settings } from 'src/shared/models/settings.model';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DatabucketsMenuComponent implements OnInit, OnDestroy {
-  @ViewChild('databucketsMenu') private databucketsMenu: ElementRef;
   public settings$: Observable<Settings>;
   public activeEnvironment$: Observable<Environment>;
   public databucketList$: Observable<DataBucket[]>;
@@ -51,13 +48,13 @@ export class DatabucketsMenuComponent implements OnInit, OnDestroy {
   public focusableInputs = FocusableInputs;
   public os$: Observable<string>;
   public menuSize = Config.defaultSecondaryMenuSize;
+  public trackByUuid = trackByUuid;
   private destroy$ = new Subject<void>();
 
   constructor(
     private environmentsService: EnvironmentsService,
     private store: Store,
     private eventsService: EventsService,
-    private uiService: UIService,
     private formBuilder: FormBuilder
   ) {}
 
@@ -86,15 +83,6 @@ export class DatabucketsMenuComponent implements OnInit, OnDestroy {
       distinctUntilChanged(),
       map((activeEnvironment) => activeEnvironment.data)
     );
-
-    this.uiService.scrollDatabucketsMenu
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((scrollDirection) => {
-        this.uiService.scroll(
-          this.databucketsMenu.nativeElement,
-          scrollDirection
-        );
-      });
 
     this.databucketsFilter.valueChanges
       .pipe(

--- a/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
+++ b/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
@@ -21,12 +21,12 @@
       </li>
     </ul>
   </div>
-  <ul class="nav flex-column flex-fill menu-list" #environmentsMenu>
+  <ul class="nav flex-column flex-fill menu-list">
     <ng-container *ngIf="environments$ | async as environments">
       <ng-container *ngIf="activeEnvironment$ | async as activeEnvironment">
         <ng-container *ngIf="environmentsStatus$ | async as environmentsStatus">
           <li
-            *ngFor="let environment of environments"
+            *ngFor="let environment of environments; trackBy: trackByUuid"
             class="nav-item"
             appDraggable
             appDropzone
@@ -47,6 +47,7 @@
                 'need-restart':
                   environmentsStatus[environment.uuid]?.needRestart
               }"
+              appScrollWhenActive
               (click)="selectEnvironment(environment.uuid)"
               (contextmenu)="openContextMenu(environment.uuid, $event)"
             >

--- a/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.ts
+++ b/packages/desktop/src/renderer/app/components/menus/environments-menu/environments-menu.component.ts
@@ -1,15 +1,12 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   OnDestroy,
-  OnInit,
-  ViewChild
+  OnInit
 } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Environment, Environments } from '@mockoon/commons';
-import { merge, Observable, Subject } from 'rxjs';
+import { Observable, Subject, merge } from 'rxjs';
 import {
   distinctUntilKeyChanged,
   filter,
@@ -18,16 +15,15 @@ import {
   tap
 } from 'rxjs/operators';
 import { EnvironmentsContextMenu } from 'src/renderer/app/components/context-menu/context-menus';
+import { trackByUuid } from 'src/renderer/app/libs/utils.lib';
 import { ContextMenuEvent } from 'src/renderer/app/models/context-menu.model';
 import { EnvironmentsStatuses } from 'src/renderer/app/models/store.model';
 import {
   DraggableContainers,
-  DropAction,
-  ScrollDirection
+  DropAction
 } from 'src/renderer/app/models/ui.model';
 import { EnvironmentsService } from 'src/renderer/app/services/environments.service';
 import { EventsService } from 'src/renderer/app/services/events.service';
-import { UIService } from 'src/renderer/app/services/ui.service';
 import { Store } from 'src/renderer/app/stores/store';
 import { Config } from 'src/renderer/config';
 import { Settings } from 'src/shared/models/settings.model';
@@ -38,11 +34,7 @@ import { Settings } from 'src/shared/models/settings.model';
   styleUrls: ['./environments-menu.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EnvironmentsMenuComponent
-  implements OnInit, AfterViewInit, OnDestroy
-{
-  @ViewChild('environmentsMenu')
-  private environmentsMenu: ElementRef;
+export class EnvironmentsMenuComponent implements OnInit, OnDestroy {
   public activeEnvironment$: Observable<Environment>;
   public environments$: Observable<Environments>;
   public environmentsStatus$: Observable<EnvironmentsStatuses>;
@@ -52,14 +44,14 @@ export class EnvironmentsMenuComponent
   public activeEnvironmentForm: FormGroup;
   public dragEnabled = true;
   public logsRecording$ = this.eventsService.logsRecording$;
+  public trackByUuid = trackByUuid;
   private destroy$ = new Subject<void>();
 
   constructor(
     private formBuilder: FormBuilder,
     private environmentsService: EnvironmentsService,
     private store: Store,
-    private eventsService: EventsService,
-    private uiService: UIService
+    private eventsService: EventsService
   ) {}
 
   ngOnInit() {
@@ -70,15 +62,6 @@ export class EnvironmentsMenuComponent
 
     this.initForms();
     this.initFormValues();
-  }
-
-  ngAfterViewInit() {
-    this.uiService.scrollEnvironmentsMenu.subscribe((scrollDirection) => {
-      this.uiService.scroll(
-        this.environmentsMenu.nativeElement,
-        scrollDirection
-      );
-    });
   }
 
   ngOnDestroy() {
@@ -106,28 +89,14 @@ export class EnvironmentsMenuComponent
    * Create a new environment. Append at the end of the list.
    */
   public addEnvironment() {
-    this.environmentsService
-      .addEnvironment()
-      .pipe(
-        tap(() => {
-          this.uiService.scrollToBottom(this.environmentsMenu.nativeElement);
-        })
-      )
-      .subscribe();
+    this.environmentsService.addEnvironment().subscribe();
   }
 
   /**
    * Open an environment. Append at the end of the list.
    */
   public openEnvironment() {
-    this.environmentsService
-      .openEnvironment()
-      .pipe(
-        tap(() => {
-          this.uiService.scrollToBottom(this.environmentsMenu.nativeElement);
-        })
-      )
-      .subscribe();
+    this.environmentsService.openEnvironment().subscribe();
   }
 
   /**
@@ -135,7 +104,6 @@ export class EnvironmentsMenuComponent
    */
   public selectEnvironment(environmentUUID: string) {
     this.environmentsService.setActiveEnvironment(environmentUUID);
-    this.uiService.scrollRoutesMenu.next(ScrollDirection.TOP);
   }
 
   /**

--- a/packages/desktop/src/renderer/app/components/menus/routes-menu/routes-menu.component.html
+++ b/packages/desktop/src/renderer/app/components/menus/routes-menu/routes-menu.component.html
@@ -94,7 +94,7 @@
     let-parentChainId="parentChainId"
     let-level="level"
   >
-    <ng-container *ngFor="let child of folder.children">
+    <ng-container *ngFor="let child of folder.children; trackBy: trackByUuid">
       <ng-container
         *ngIf="child.type === 'folder'"
         [ngTemplateOutlet]="folderItemTemplate"
@@ -149,6 +149,7 @@
           'padding-left.rem':
             (routesFilter$ | async) || !level ? undefined : level * 2 + 0.5
         }"
+        appScrollWhenActive
         [formGroup]="folderForm"
         (click)="toggleCollapse(folder)"
       >
@@ -239,6 +240,7 @@
             active: (activeRoute$ | async)?.uuid === route.uuid,
             'route-disabled': !route.enabled
           }"
+          appScrollWhenActive
           (click)="selectRoute(route.uuid)"
           (contextmenu)="openContextMenu('route', route.uuid, $event, parentId)"
         >

--- a/packages/desktop/src/renderer/app/components/menus/routes-menu/routes-menu.component.ts
+++ b/packages/desktop/src/renderer/app/components/menus/routes-menu/routes-menu.component.ts
@@ -66,7 +66,8 @@ type FullFolder = {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RoutesMenuComponent implements OnInit, OnDestroy {
-  @ViewChild('routesMenu') private routesMenu: ElementRef<HTMLUListElement>;
+  @ViewChild('routesMenu')
+  private routesMenu: ElementRef<HTMLUListElement>;
   public settings$: Observable<Settings>;
   public activeEnvironment$: Observable<Environment>;
   public rootFolder$: Observable<FullFolder>;
@@ -132,12 +133,6 @@ export class RoutesMenuComponent implements OnInit, OnDestroy {
       })
     );
 
-    this.uiService.scrollRoutesMenu
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((scrollDirection) => {
-        this.uiService.scroll(this.routesMenu.nativeElement, scrollDirection);
-      });
-
     this.routesFilter.valueChanges
       .pipe(
         debounceTime(10),
@@ -172,7 +167,7 @@ export class RoutesMenuComponent implements OnInit, OnDestroy {
    * Create a new route in the current environment. Append at the end of the list
    */
   public addCRUDRoute() {
-    this.environmentsService.addCRUDRoute('root', true);
+    this.environmentsService.addCRUDRoute('root');
   }
 
   /**
@@ -186,14 +181,21 @@ export class RoutesMenuComponent implements OnInit, OnDestroy {
    * Create a new route in the current environment. Append at the end of the list
    */
   public addHTTPRoute() {
-    this.environmentsService.addHTTPRoute('root', true);
+    this.environmentsService.addHTTPRoute('root');
   }
 
   /**
    * Create a new folder in the current environment
    */
   public addFolder() {
-    this.environmentsService.addFolder('root', true);
+    this.environmentsService.addFolder('root');
+
+    // manually scroll to the bottom when adding a new folder as they cannot use the scrollWhenActive directive
+    this.uiService.scrollToBottom(this.routesMenu.nativeElement);
+  }
+
+  public trackByUuid(index: number, child: { data: { uuid: string } }) {
+    return child.data.uuid;
   }
 
   /**

--- a/packages/desktop/src/renderer/app/components/modals/templates-modal/templates-modal.component.ts
+++ b/packages/desktop/src/renderer/app/components/modals/templates-modal/templates-modal.component.ts
@@ -294,7 +294,7 @@ export class TemplatesModalComponent implements OnInit, OnDestroy {
     activeTemplateTab: TemplatesTabsName,
     activeTemplate: Template
   ) {
-    let options: Parameters<EnvironmentsService['addCRUDRoute']>[2];
+    let options: Parameters<EnvironmentsService['addCRUDRoute']>[1];
 
     if (activeTemplateTab === 'LIST') {
       options = {
@@ -316,7 +316,7 @@ export class TemplatesModalComponent implements OnInit, OnDestroy {
       };
     }
 
-    this.environmentsService.addCRUDRoute('root', true, options);
+    this.environmentsService.addCRUDRoute('root', options);
     this.modalService.dismissAll();
   }
 
@@ -324,7 +324,7 @@ export class TemplatesModalComponent implements OnInit, OnDestroy {
     activeTemplateTab: TemplatesTabsName,
     activeTemplate: Template
   ) {
-    let options: Parameters<EnvironmentsService['addHTTPRoute']>[2];
+    let options: Parameters<EnvironmentsService['addHTTPRoute']>[1];
 
     if (activeTemplateTab === 'LIST') {
       options = {
@@ -337,7 +337,7 @@ export class TemplatesModalComponent implements OnInit, OnDestroy {
         body: this.templatesService.lastGeneratedTemplate$.value
       };
     }
-    this.environmentsService.addHTTPRoute('root', true, options);
+    this.environmentsService.addHTTPRoute('root', options);
     this.modalService.dismissAll();
   }
 

--- a/packages/desktop/src/renderer/app/directives/scroll-to-active.directive.ts
+++ b/packages/desktop/src/renderer/app/directives/scroll-to-active.directive.ts
@@ -1,0 +1,54 @@
+import { AfterViewInit, Directive, ElementRef, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * This directive is used to scroll the element into view when it becomes active (class added) or when the element is created with the active class (element insertion, click or class change from outside, like the command palette).
+ */
+@Directive({
+  selector: '[appScrollWhenActive]'
+})
+export class ScrollWhenActiveDirective implements AfterViewInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+  private mutationObserver = new MutationObserver(
+    this.observeClassChanges.bind(this)
+  );
+
+  constructor(private elementRef: ElementRef) {}
+
+  ngAfterViewInit() {
+    this.mutationObserver.observe(this.elementRef.nativeElement, {
+      attributes: true
+    });
+
+    this.scrollIntoView();
+  }
+
+  ngOnDestroy() {
+    this.mutationObserver.disconnect();
+    this.destroy$.next();
+    this.destroy$.unsubscribe();
+  }
+
+  private observeClassChanges(mutations: MutationRecord[]) {
+    mutations.forEach((mutation) => {
+      if (
+        mutation.type === 'attributes' &&
+        mutation.attributeName === 'class'
+      ) {
+        this.scrollIntoView();
+      }
+    });
+  }
+
+  private scrollIntoView() {
+    if (this.elementRef.nativeElement.classList.contains('active')) {
+      setTimeout(() => {
+        this.elementRef.nativeElement.scrollIntoView({
+          behavior: 'instant',
+          block: 'nearest',
+          inline: 'nearest'
+        });
+      }, 0);
+    }
+  }
+}

--- a/packages/desktop/src/renderer/app/libs/utils.lib.ts
+++ b/packages/desktop/src/renderer/app/libs/utils.lib.ts
@@ -137,3 +137,5 @@ export const environmentHasRoute = (
   route: Route | Pick<Route, 'type' | 'endpoint' | 'method'>
 ): boolean =>
   environment.routes.some((envRoute) => isRouteDuplicates(envRoute, route));
+
+export const trackByUuid = (item) => item.uuid;

--- a/packages/desktop/src/renderer/app/models/ui.model.ts
+++ b/packages/desktop/src/renderer/app/models/ui.model.ts
@@ -20,11 +20,6 @@ export type DragState = {
   nativeElement: HTMLElement;
 };
 
-export enum ScrollDirection {
-  TOP = 'TOP',
-  BOTTOM = 'BOTTOM'
-}
-
 export type ConfirmModalPayload = {
   title: string;
   text: string;

--- a/packages/desktop/src/renderer/app/services/command-palette.service.ts
+++ b/packages/desktop/src/renderer/app/services/command-palette.service.ts
@@ -622,7 +622,7 @@ export class CommandPaletteService {
         shortcut$: this.ctrlOrCmd$(['Shift', 'R']),
         action: () => {
           this.environmentsService.setActiveView('ENV_ROUTES');
-          this.environmentsService.addHTTPRoute('root', true);
+          this.environmentsService.addHTTPRoute('root');
         },
         score: 1,
         enabled: hasActiveEnvironment
@@ -632,7 +632,7 @@ export class CommandPaletteService {
         label: 'Create a New CRUD Route',
         action: () => {
           this.environmentsService.setActiveView('ENV_ROUTES');
-          this.environmentsService.addCRUDRoute('root', true);
+          this.environmentsService.addCRUDRoute('root');
         },
         score: 1,
         enabled: hasActiveEnvironment
@@ -642,7 +642,7 @@ export class CommandPaletteService {
         label: 'Create a New Route Folder',
         action: () => {
           this.environmentsService.setActiveView('ENV_ROUTES');
-          this.environmentsService.addFolder('root', true);
+          this.environmentsService.addFolder('root');
         },
         score: 1,
         enabled: hasActiveEnvironment

--- a/packages/desktop/src/renderer/app/services/environments.service.ts
+++ b/packages/desktop/src/renderer/app/services/environments.service.ts
@@ -72,8 +72,7 @@ import {
 } from 'src/renderer/app/models/store.model';
 import {
   DraggableContainers,
-  DropAction,
-  ScrollDirection
+  DropAction
 } from 'src/renderer/app/models/ui.model';
 import { DataService } from 'src/renderer/app/services/data.service';
 import { DialogsService } from 'src/renderer/app/services/dialogs.service';
@@ -490,8 +489,6 @@ export class EnvironmentsService extends Logger {
             insertAfterIndex
           })
         );
-
-        this.uiService.scrollEnvironmentsMenu.next(ScrollDirection.BOTTOM);
       })
     );
   }
@@ -649,13 +646,9 @@ export class EnvironmentsService extends Logger {
   /**
    * Add a new folder and save it in the store
    */
-  public addFolder(folderId: string | 'root', scroll = false) {
+  public addFolder(folderId: string | 'root') {
     if (this.store.getActiveEnvironment()) {
       this.store.update(addFolderAction(BuildFolder(), folderId));
-
-      if (scroll) {
-        this.uiService.scrollRoutesMenu.next(ScrollDirection.BOTTOM);
-      }
     }
   }
 
@@ -680,7 +673,6 @@ export class EnvironmentsService extends Logger {
    */
   public addHTTPRoute(
     folderId: string | 'root',
-    scroll = false,
     options: {
       endpoint: typeof RouteDefault.endpoint;
       body: typeof RouteResponseDefault.body;
@@ -694,10 +686,6 @@ export class EnvironmentsService extends Logger {
         addRouteAction(BuildHTTPRoute(true, options), folderId)
       );
 
-      if (scroll) {
-        this.uiService.scrollRoutesMenu.next(ScrollDirection.BOTTOM);
-      }
-
       setTimeout(() => {
         this.uiService.focusInput(FocusableInputs.ROUTE_PATH);
       }, 0);
@@ -709,7 +697,6 @@ export class EnvironmentsService extends Logger {
    */
   public addCRUDRoute(
     folderId: string | 'root',
-    scroll = false,
     options: {
       endpoint: typeof RouteDefault.endpoint;
       dataBucket: Partial<DataBucket>;
@@ -735,10 +722,6 @@ export class EnvironmentsService extends Logger {
 
       this.store.update(addRouteAction(newCRUDRoute, folderId));
 
-      if (scroll) {
-        this.uiService.scrollRoutesMenu.next(ScrollDirection.BOTTOM);
-      }
-
       setTimeout(() => {
         this.uiService.focusInput(FocusableInputs.ROUTE_PATH);
       }, 0);
@@ -754,7 +737,6 @@ export class EnvironmentsService extends Logger {
       newDatabucket = this.dataService.deduplicateDatabucketID(newDatabucket);
 
       this.store.update(addDatabucketAction(newDatabucket));
-      this.uiService.scrollDatabucketsMenu.next(ScrollDirection.BOTTOM);
 
       setTimeout(() => {
         this.uiService.focusInput(FocusableInputs.DATABUCKET_NAME);
@@ -794,7 +776,6 @@ export class EnvironmentsService extends Logger {
         }
       }),
       tap(() => {
-        this.uiService.scrollRoutesMenu.next(ScrollDirection.BOTTOM);
         this.uiService.focusInput(FocusableInputs.ROUTE_PATH);
       }),
       catchError((error) => {
@@ -1440,7 +1421,5 @@ export class EnvironmentsService extends Logger {
         filePath
       })
     );
-
-    this.uiService.scrollEnvironmentsMenu.next(ScrollDirection.BOTTOM);
   }
 }

--- a/packages/desktop/src/renderer/app/services/ui.service.ts
+++ b/packages/desktop/src/renderer/app/services/ui.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { Subject } from 'rxjs';
 import { AuthModalComponent } from 'src/renderer/app/components/modals/auth-modal/auth-modal.component';
 import { ChangelogModalComponent } from 'src/renderer/app/components/modals/changelog-modal/changelog-modal.component';
 import { CommandPaletteModalComponent } from 'src/renderer/app/components/modals/command-palette-modal/command-palette-modal.component';
@@ -12,7 +11,6 @@ import { TemplatesModalComponent } from 'src/renderer/app/components/modals/temp
 import { WelcomeModalComponent } from 'src/renderer/app/components/modals/welcome-modal/welcome-modal.component';
 import { FocusableInputs } from 'src/renderer/app/enums/ui.enum';
 import { UIStateProperties } from 'src/renderer/app/models/store.model';
-import { ScrollDirection } from 'src/renderer/app/models/ui.model';
 import { EventsService } from 'src/renderer/app/services/events.service';
 import { updateUIStateAction } from 'src/renderer/app/stores/actions';
 import { Store } from 'src/renderer/app/stores/store';
@@ -34,10 +32,6 @@ const commonConfigs = {
 
 @Injectable({ providedIn: 'root' })
 export class UIService {
-  public scrollEnvironmentsMenu: Subject<ScrollDirection> = new Subject();
-  public scrollRoutesMenu: Subject<ScrollDirection> = new Subject();
-  public scrollDatabucketsMenu: Subject<ScrollDirection> = new Subject();
-
   private modals = {
     commandPalette: {
       component: CommandPaletteModalComponent,
@@ -111,31 +105,6 @@ export class UIService {
     setTimeout(() => {
       element.scrollTop = element.scrollHeight;
     });
-  }
-
-  /**
-   * Scroll to top of an element
-   *
-   * @param element
-   */
-  public scrollToTop(element: Element) {
-    setTimeout(() => {
-      element.scrollTop = 0;
-    });
-  }
-
-  /**
-   * Scroll an element to a direction
-   *
-   * @param element
-   * @param direction
-   */
-  public scroll(element: Element, direction: ScrollDirection) {
-    if (direction === ScrollDirection.TOP) {
-      this.scrollToTop(element);
-    } else if (direction === ScrollDirection.BOTTOM) {
-      this.scrollToBottom(element);
-    }
   }
 
   /**


### PR DESCRIPTION
Use a directive focusing elements with .active class instead of event emitters. This also neatly refocus menu items when navigating between tabs

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
