### PR TITLE
Add searching and filtering for CRUD routes with query params

### DIFF
--- a/packages/commons-server/src/libs/filters.ts
+++ b/packages/commons-server/src/libs/filters.ts
@@ -5,9 +5,11 @@ const isNum = (value: string) => !isNaN(parseFloat(value));
 
 export const FILTERS = {
   eq: (data, query) =>
-    String(data) === query || (isNum(data) && isNum(query) && data == query),
+    String(data) === query ||
+    (isNum(data) && isNum(query) && Number(data) === Number(query)),
   ne: (data, query) =>
-    String(data) !== query && (!isNum(data) || !isNum(query) || data != query),
+    String(data) !== query &&
+    (!isNum(data) || !isNum(query) || Number(data) !== Number(query)),
   gt: (data, query) => data > query,
   gte: (data, query) => data >= query,
   lt: (data, query) => data < query,
@@ -23,6 +25,10 @@ export function parseFilters(queryParams: Request['query']): FilterData[] {
   const result: FilterData[] = [];
 
   for (const key in queryParams) {
+    if (!queryParams.hasOwnProperty(key)) {
+      continue;
+    }
+
     const value = queryParams[key] as string;
     const match = key.match(FILTERS_REGEX);
 

--- a/packages/commons-server/src/libs/filters.ts
+++ b/packages/commons-server/src/libs/filters.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express';
+import { get as objectGet } from 'object-path';
+
+const isNum = (value: string) => !isNaN(parseFloat(value));
+
+export const FILTERS = {
+  eq: (data, query) =>
+    String(data) === query || (isNum(data) && isNum(query) && data == query),
+  ne: (data, query) =>
+    String(data) !== query && (!isNum(data) || !isNum(query) || data != query),
+  gt: (data, query) => data > query,
+  gte: (data, query) => data >= query,
+  lt: (data, query) => data < query,
+  lte: (data, query) => data <= query,
+  like: (data, query) => new RegExp(query, 'i').test(String(data)),
+  start: (data, query) => new RegExp(`^${query}`, 'i').test(String(data)),
+  end: (data, query) => new RegExp(`${query}$`, 'i').test(String(data))
+} satisfies Record<string, (data: any, query: string) => boolean>;
+
+const FILTERS_REGEX = `^(.*)_(${Object.keys(FILTERS).join('|')})$`;
+
+export function parseFilters(queryParams: Request['query']): FilterData[] {
+  const result: FilterData[] = [];
+
+  for (const key in queryParams) {
+    const value = queryParams[key] as string;
+    const match = key.match(FILTERS_REGEX);
+
+    if (match) {
+      const [, path, filter] = match as [string, string, Filter];
+      result.push({ path, filter, value });
+    }
+  }
+
+  return result;
+}
+
+export function applyFilter(data: any, filterData: FilterData): boolean {
+  const { filter, path, value } = filterData;
+
+  return FILTERS[filter](objectGet(data, path), value);
+}
+
+export type Filter = keyof typeof FILTERS;
+
+export type FilterData = {
+  path: string;
+  filter: Filter;
+  value: string;
+};

--- a/packages/commons-server/src/libs/server/crud.ts
+++ b/packages/commons-server/src/libs/server/crud.ts
@@ -152,10 +152,13 @@ export const databucketActions = (
           : 'asc';
 
       if (Array.isArray(responseBody)) {
+        response.set('X-Total-Count', responseBody.length.toString());
+
         if (search != null) {
-          response.set('X-Total-Count', responseBody.length.toString());
           responseBody = responseBody.filter((r) => fullTextSearch(r, search));
         }
+
+        response.set('X-Filtered-Count', responseBody.length.toString());
 
         if (sort != null) {
           responseBody = responseBody.slice().sort((a, b) => {
@@ -181,10 +184,6 @@ export const databucketActions = (
           request.query.limit !== undefined ||
           request.query.page !== undefined
         ) {
-          response.set(
-            search != null ? 'X-Filtered-Count' : 'X-Total-Count',
-            responseBody.length.toString()
-          );
           responseBody = responseBody.slice((page - 1) * limit, page * limit);
         }
       }

--- a/packages/commons-server/src/libs/server/crud.ts
+++ b/packages/commons-server/src/libs/server/crud.ts
@@ -4,6 +4,7 @@ import {
   RouteResponse
 } from '@mockoon/commons';
 import { Request, Response } from 'express';
+import { applyFilter, parseFilters } from '../filters';
 import { dedupSlashes, fullTextSearch } from '../utils';
 
 export type CrudRouteIds =
@@ -150,6 +151,7 @@ export const databucketActions = (
             ? request.query.order
             : 'asc'
           : 'asc';
+      const filters = parseFilters(request.query);
 
       if (Array.isArray(responseBody)) {
         response.set('X-Total-Count', responseBody.length.toString());
@@ -158,6 +160,9 @@ export const databucketActions = (
           responseBody = responseBody.filter((r) => fullTextSearch(r, search));
         }
 
+        responseBody = responseBody.filter((r) =>
+          filters.every((f) => applyFilter(r, f))
+        );
         response.set('X-Filtered-Count', responseBody.length.toString());
 
         if (sort != null) {

--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -330,3 +330,20 @@ export const dedupSlashes = (str: string) => str.replace(/\/{2,}/g, '/');
  */
 export const preparePath = (endpointPrefix: string, endpoint: string) =>
   dedupSlashes(`/${endpointPrefix}/${endpoint.replace(/ /g, '%20')}`);
+
+/**
+ * Perform a full text search on an object. The object can be any valid JSON type
+ *
+ * @param object
+ * @param query
+ * @returns
+ */
+export const fullTextSearch = (object: unknown, query: string): boolean => {
+  if (typeof object === 'object' || typeof object === 'boolean') {
+    return Object.values(object ?? []).some((value) =>
+      fullTextSearch(value, query)
+    );
+  }
+
+  return new RegExp(query, 'i').test(String(object));
+};

--- a/packages/commons-server/test/suites/filters.spec.ts
+++ b/packages/commons-server/test/suites/filters.spec.ts
@@ -525,6 +525,11 @@ describe('Filters', () => {
       it('should return false if the data does not match the query', () => {
         expect(FILTERS.like('peter', 'o')).to.be.false;
       });
+
+      it('should match a regex', () => {
+        expect(FILTERS.like('peter', 'p.*r')).to.be.true;
+        expect(FILTERS.like('1', '^(1|2|3)$')).to.be.true;
+      });
     });
 
     describe('start', () => {
@@ -543,6 +548,11 @@ describe('Filters', () => {
       it('should return false if the data does not start with the query', () => {
         expect(FILTERS.start('peter', 'e')).to.be.false;
       });
+
+      it('should match a regex', () => {
+        expect(FILTERS.like('peter', 'p.*r')).to.be.true;
+        expect(FILTERS.like('1', '(1|2|3)$')).to.be.true;
+      });
     });
 
     describe('end', () => {
@@ -560,6 +570,11 @@ describe('Filters', () => {
 
       it('should return false if the data does not end with the query', () => {
         expect(FILTERS.end('peter', 'e')).to.be.false;
+      });
+
+      it('should match a regex', () => {
+        expect(FILTERS.like('peter', 'p.*r')).to.be.true;
+        expect(FILTERS.like('1', '^(1|2|3)')).to.be.true;
       });
     });
   });

--- a/packages/commons-server/test/suites/filters.spec.ts
+++ b/packages/commons-server/test/suites/filters.spec.ts
@@ -129,6 +129,15 @@ describe('Filters', () => {
       expect(parseFilters(queryParams)).to.deep.equal(expected);
     });
 
+    it('should accept nested paths (array)', () => {
+      const queryParams = { 'users.0.name_eq': 'peter' };
+      const expected: FilterData[] = [
+        { path: 'users.0.name', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
     it('should accept paths with underscores', () => {
       const queryParams = { user_name_eq: 'peter' };
       const expected: FilterData[] = [
@@ -252,6 +261,28 @@ describe('Filters', () => {
         path: 'name',
         filter: 'end',
         value: 'r'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should accept nested paths', () => {
+      const data = { user: { name: 'peter' } };
+      const filterData: FilterData = {
+        path: 'user.name',
+        filter: 'eq',
+        value: 'peter'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should accept nested paths (array)', () => {
+      const data = { users: [{ name: 'peter' }] };
+      const filterData: FilterData = {
+        path: 'users.0.name',
+        filter: 'eq',
+        value: 'peter'
       };
 
       expect(applyFilter(data, filterData)).to.be.true;

--- a/packages/commons-server/test/suites/filters.spec.ts
+++ b/packages/commons-server/test/suites/filters.spec.ts
@@ -1,0 +1,504 @@
+import { expect } from 'chai';
+import {
+  FILTERS,
+  FilterData,
+  applyFilter,
+  parseFilters
+} from '../../src/libs/filters';
+
+describe('Filters', () => {
+  describe('parseFilters', () => {
+    it('should parse the "eq" filter', () => {
+      const queryParams = { name_eq: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "ne" filter', () => {
+      const queryParams = { name_ne: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'ne', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "gt" filter', () => {
+      const queryParams = { age_gt: '18' };
+      const expected: FilterData[] = [
+        { path: 'age', filter: 'gt', value: '18' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "gte" filter', () => {
+      const queryParams = { age_gte: '18' };
+      const expected: FilterData[] = [
+        { path: 'age', filter: 'gte', value: '18' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "lt" filter', () => {
+      const queryParams = { age_lt: '18' };
+      const expected: FilterData[] = [
+        { path: 'age', filter: 'lt', value: '18' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "lte" filter', () => {
+      const queryParams = { age_lte: '18' };
+      const expected: FilterData[] = [
+        { path: 'age', filter: 'lte', value: '18' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "like" filter', () => {
+      const queryParams = { name_like: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'like', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "start" filter', () => {
+      const queryParams = { name_start: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'start', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse the "end" filter', () => {
+      const queryParams = { name_end: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'end', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should parse multiple filters', () => {
+      const queryParams = {
+        name_eq: 'peter',
+        age_gt: '18',
+        age_lt: '30'
+      };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'eq', value: 'peter' },
+        { path: 'age', filter: 'gt', value: '18' },
+        { path: 'age', filter: 'lt', value: '30' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should ignore invalid filters', () => {
+      const queryParams = {
+        name_eq: 'peter',
+        age_gt: '18',
+        age_lt: '30',
+        invalid: 'filter'
+      };
+      const expected: FilterData[] = [
+        { path: 'name', filter: 'eq', value: 'peter' },
+        { path: 'age', filter: 'gt', value: '18' },
+        { path: 'age', filter: 'lt', value: '30' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should accept nested paths', () => {
+      const queryParams = { 'user.name_eq': 'peter' };
+      const expected: FilterData[] = [
+        { path: 'user.name', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should accept paths with underscores', () => {
+      const queryParams = { user_name_eq: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'user_name', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should accept paths with underscores containing a filter name', () => {
+      const queryParams = { user_like_like: 'peter' };
+      const expected: FilterData[] = [
+        { path: 'user_like', filter: 'like', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+
+    it('should accept more complex object-path notation', () => {
+      const queryParams = { 'user.0.name_eq': 'peter' };
+      const expected: FilterData[] = [
+        { path: 'user.0.name', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
+  });
+
+  describe('applyFilter', () => {
+    it('should apply the "eq" filter', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: 'name',
+        filter: 'eq',
+        value: 'peter'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "ne" filter', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: 'name',
+        filter: 'ne',
+        value: 'john'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "gt" filter', () => {
+      const data = { age: 20 };
+      const filterData: FilterData = {
+        path: 'age',
+        filter: 'gt',
+        value: '18'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "gte" filter', () => {
+      const data = { age: 20 };
+      const filterData: FilterData = {
+        path: 'age',
+        filter: 'gte',
+        value: '18'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "lt" filter', () => {
+      const data = { age: 20 };
+      const filterData: FilterData = {
+        path: 'age',
+        filter: 'lt',
+        value: '30'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "lte" filter', () => {
+      const data = { age: 20 };
+      const filterData: FilterData = {
+        path: 'age',
+        filter: 'lte',
+        value: '30'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "like" filter', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: 'name',
+        filter: 'like',
+        value: 'et'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "start" filter', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: 'name',
+        filter: 'start',
+        value: 'p'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should apply the "end" filter', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: 'name',
+        filter: 'end',
+        value: 'r'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+  });
+
+  describe('FILTERS', () => {
+    describe('eq', () => {
+      it('should return true if the data is equal to the query', () => {
+        expect(FILTERS.eq('peter', 'peter')).to.be.true;
+      });
+
+      it('should return true if the data is equal to the query (number)', () => {
+        expect(FILTERS.eq(18, '18')).to.be.true;
+      });
+
+      it('should return true if the data is equal to the query (number, more complex)', () => {
+        expect(FILTERS.eq(18, '+18.00')).to.be.true;
+      });
+
+      it('should return false if the data is different from the query', () => {
+        expect(FILTERS.eq('peter', 'john')).to.be.false;
+      });
+
+      it('should work for "true"', () => {
+        expect(FILTERS.eq(true, 'true')).to.be.true;
+      });
+
+      it('should work for "false"', () => {
+        expect(FILTERS.eq(false, 'false')).to.be.true;
+      });
+
+      it('should work for "null"', () => {
+        expect(FILTERS.eq(null, 'null')).to.be.true;
+      });
+
+      it('should work on edge cases', () => {
+        expect(FILTERS.eq('', '0')).to.be.false;
+        expect(FILTERS.eq('', 'null')).to.be.false;
+        expect(FILTERS.eq('', 'false')).to.be.false;
+        expect(FILTERS.eq(0, '')).to.be.false;
+        expect(FILTERS.eq(0, 'null')).to.be.false;
+        expect(FILTERS.eq(0, 'false')).to.be.false;
+        expect(FILTERS.eq('0', '')).to.be.false;
+        expect(FILTERS.eq('0', 'null')).to.be.false;
+        expect(FILTERS.eq('0', 'false')).to.be.false;
+        expect(FILTERS.eq(null, '')).to.be.false;
+        expect(FILTERS.eq(null, '0')).to.be.false;
+        expect(FILTERS.eq(null, 'false')).to.be.false;
+        expect(FILTERS.eq(false, '')).to.be.false;
+        expect(FILTERS.eq(false, '0')).to.be.false;
+        expect(FILTERS.eq(false, 'null')).to.be.false;
+      });
+    });
+
+    describe('ne', () => {
+      it('should return false if the data is equal to the query', () => {
+        expect(FILTERS.ne('peter', 'peter')).to.be.false;
+      });
+
+      it('should return false if the data is equal to the query (number)', () => {
+        expect(FILTERS.ne(18, '18')).to.be.false;
+      });
+
+      it('should return false if the data is equal to the query (number, more complex)', () => {
+        expect(FILTERS.ne(18, '+18.00')).to.be.false;
+      });
+
+      it('should return true if the data is different from the query', () => {
+        expect(FILTERS.ne('peter', 'john')).to.be.true;
+      });
+
+      it('should work for "true"', () => {
+        expect(FILTERS.ne(true, 'true')).to.be.false;
+      });
+
+      it('should work for "false"', () => {
+        expect(FILTERS.ne(false, 'false')).to.be.false;
+      });
+
+      it('should work for "null"', () => {
+        expect(FILTERS.ne(null, 'null')).to.be.false;
+      });
+
+      it('should work on edge cases', () => {
+        expect(FILTERS.ne('', '0')).to.be.true;
+        expect(FILTERS.ne('', 'null')).to.be.true;
+        expect(FILTERS.ne('', 'false')).to.be.true;
+        expect(FILTERS.ne(0, '')).to.be.true;
+        expect(FILTERS.ne(0, 'null')).to.be.true;
+        expect(FILTERS.ne(0, 'false')).to.be.true;
+        expect(FILTERS.ne('0', '')).to.be.true;
+        expect(FILTERS.ne('0', 'null')).to.be.true;
+        expect(FILTERS.ne('0', 'false')).to.be.true;
+        expect(FILTERS.ne(null, '')).to.be.true;
+        expect(FILTERS.ne(null, '0')).to.be.true;
+        expect(FILTERS.ne(null, 'false')).to.be.true;
+        expect(FILTERS.ne(false, '')).to.be.true;
+        expect(FILTERS.ne(false, '0')).to.be.true;
+        expect(FILTERS.ne(false, 'null')).to.be.true;
+      });
+    });
+
+    describe('gt', () => {
+      it('should return true if the data is greater than the query', () => {
+        expect(FILTERS.gt(2, '1')).to.be.true;
+      });
+
+      it('should return false if the data is equal to the query', () => {
+        expect(FILTERS.gt(2, '2')).to.be.false;
+      });
+
+      it('should return false if the data is less than the query', () => {
+        expect(FILTERS.gt(2, '3')).to.be.false;
+      });
+
+      it('should use number ordering on numbers', () => {
+        expect(FILTERS.gt(2, '10')).to.be.false;
+      });
+
+      it('should use string ordering on strings', () => {
+        expect(FILTERS.gt('2', '10')).to.be.true;
+      });
+    });
+
+    describe('gte', () => {
+      it('should return true if the data is greater than the query', () => {
+        expect(FILTERS.gte(2, '1')).to.be.true;
+      });
+
+      it('should return true if the data is equal to the query', () => {
+        expect(FILTERS.gte(2, '2')).to.be.true;
+      });
+
+      it('should return false if the data is less than the query', () => {
+        expect(FILTERS.gte(2, '3')).to.be.false;
+      });
+
+      it('should use number ordering on numbers', () => {
+        expect(FILTERS.gte(2, '10')).to.be.false;
+      });
+
+      it('should use string ordering on strings', () => {
+        expect(FILTERS.gte('2', '10')).to.be.true;
+      });
+    });
+
+    describe('lt', () => {
+      it('should return false if the data is greater than the query', () => {
+        expect(FILTERS.lt(2, '1')).to.be.false;
+      });
+
+      it('should return false if the data is equal to the query', () => {
+        expect(FILTERS.lt(2, '2')).to.be.false;
+      });
+
+      it('should return true if the data is less than the query', () => {
+        expect(FILTERS.lt(2, '3')).to.be.true;
+      });
+
+      it('should use number ordering on numbers', () => {
+        expect(FILTERS.lt(2, '10')).to.be.true;
+      });
+
+      it('should use string ordering on strings', () => {
+        expect(FILTERS.lt('2', '10')).to.be.false;
+      });
+    });
+
+    describe('lte', () => {
+      it('should return false if the data is greater than the query', () => {
+        expect(FILTERS.lte(2, '1')).to.be.false;
+      });
+
+      it('should return true if the data is equal to the query', () => {
+        expect(FILTERS.lte(2, '2')).to.be.true;
+      });
+
+      it('should return true if the data is less than the query', () => {
+        expect(FILTERS.lte(2, '3')).to.be.true;
+      });
+
+      it('should use number ordering on numbers', () => {
+        expect(FILTERS.lte(2, '10')).to.be.true;
+      });
+
+      it('should use string ordering on strings', () => {
+        expect(FILTERS.lte('2', '10')).to.be.false;
+      });
+    });
+
+    describe('like', () => {
+      it('should return true if the data matches the query', () => {
+        expect(FILTERS.like('peter', 'peter')).to.be.true;
+      });
+
+      it('should return true if the data matches the query (number)', () => {
+        expect(FILTERS.like(18, '18')).to.be.true;
+      });
+
+      it('should return true if the data contains the query', () => {
+        expect(FILTERS.like('peter', 'et')).to.be.true;
+      });
+
+      it('should match case-insensitive', () => {
+        expect(FILTERS.like('peter', 'T')).to.be.true;
+      });
+
+      it('should return false if the data does not match the query', () => {
+        expect(FILTERS.like('peter', 'o')).to.be.false;
+      });
+    });
+
+    describe('start', () => {
+      it('should return true if the data starts with the query', () => {
+        expect(FILTERS.start('peter', 'p')).to.be.true;
+      });
+
+      it('should return true if the data starts with the query (number)', () => {
+        expect(FILTERS.start(18, '1')).to.be.true;
+      });
+
+      it('should match case-insensitive', () => {
+        expect(FILTERS.start('peter', 'P')).to.be.true;
+      });
+
+      it('should return false if the data does not start with the query', () => {
+        expect(FILTERS.start('peter', 'e')).to.be.false;
+      });
+    });
+
+    describe('end', () => {
+      it('should return true if the data ends with the query', () => {
+        expect(FILTERS.end('peter', 'r')).to.be.true;
+      });
+
+      it('should return true if the data ends with the query (number)', () => {
+        expect(FILTERS.end(18, '8')).to.be.true;
+      });
+
+      it('should match case-insensitive', () => {
+        expect(FILTERS.end('peter', 'R')).to.be.true;
+      });
+
+      it('should return false if the data does not end with the query', () => {
+        expect(FILTERS.end('peter', 'e')).to.be.false;
+      });
+    });
+  });
+});

--- a/packages/commons-server/test/suites/filters.spec.ts
+++ b/packages/commons-server/test/suites/filters.spec.ts
@@ -164,6 +164,15 @@ describe('Filters', () => {
 
       expect(parseFilters(queryParams)).to.deep.equal(expected);
     });
+
+    it('should accept filters with empty path', () => {
+      const queryParams = { _eq: 'peter' };
+      const expected: FilterData[] = [
+        { path: '', filter: 'eq', value: 'peter' }
+      ];
+
+      expect(parseFilters(queryParams)).to.deep.equal(expected);
+    });
   });
 
   describe('applyFilter', () => {
@@ -286,6 +295,28 @@ describe('Filters', () => {
       };
 
       expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should filter non-object values', () => {
+      const data = 'peter';
+      const filterData: FilterData = {
+        path: '',
+        filter: 'eq',
+        value: 'peter'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.true;
+    });
+
+    it('should not filter object values if path is empty', () => {
+      const data = { name: 'peter' };
+      const filterData: FilterData = {
+        path: '',
+        filter: 'eq',
+        value: 'peter'
+      };
+
+      expect(applyFilter(data, filterData)).to.be.false;
     });
   });
 

--- a/packages/commons-server/test/suites/utils.spec.ts
+++ b/packages/commons-server/test/suites/utils.spec.ts
@@ -2,7 +2,12 @@ import { expect } from 'chai';
 import { Response } from 'express';
 import fs from 'fs';
 import { SafeString } from 'handlebars';
-import { DecompressBody, fromSafeString, ToBase64 } from '../../src/libs/utils';
+import {
+  DecompressBody,
+  fromSafeString,
+  fullTextSearch,
+  ToBase64
+} from '../../src/libs/utils';
 
 describe('Utils', () => {
   describe('toBase64', () => {
@@ -74,6 +79,149 @@ describe('Utils', () => {
       const newString = fromSafeString(new SafeString('text'));
 
       expect(newString).to.equal('text');
+    });
+  });
+
+  describe('fullTextSearch', () => {
+    it('should return true if query matches a property value in the object', () => {
+      const object = { name: 'John', age: 30 };
+      const query = 'John';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return false if query does not match any property value in the object', () => {
+      const object = { name: 'John', age: 30 };
+      const query = 'Mike';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return true if query matches a property value in the nested object', () => {
+      const object = { name: 'John', age: 30, address: { city: 'New York' } };
+      const query = 'New York';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return false if query does not match any property value in the nested object', () => {
+      const object = { name: 'John', age: 30, address: { city: 'New York' } };
+      const query = 'Los Angeles';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return true if query matches a value in the array', () => {
+      const object = {
+        name: 'John',
+        age: 30,
+        hobbies: ['reading', 'swimming']
+      };
+      const query = 'swimming';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return false if query does not match any value in the array', () => {
+      const object = {
+        name: 'John',
+        age: 30,
+        hobbies: ['reading', 'swimming']
+      };
+      const query = 'dancing';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should be case insensitive', () => {
+      const object = { name: 'John', age: 30 };
+      const query = 'john';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should find a number', () => {
+      const object = { name: 'John', age: 30 };
+      const query = '30';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return true for partial match', () => {
+      const object = { name: 'John', age: 30 };
+      const query = 'Jo';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return true for partial match with numbers', () => {
+      const object = { name: 'John', age: 30 };
+      const query = '3';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return true when object is an array', () => {
+      const object = ['John', 'Doe', 30];
+      const query = 'Doe';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return true when object is a simple string', () => {
+      const object = 'John';
+      const query = 'John';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return true when object is a simple number', () => {
+      const object = 30;
+      const query = '30';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return false when object is true and query is "true"', () => {
+      const object = true;
+      const query = 'true';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return false when object is false and query is "false"', () => {
+      const object = false;
+      const query = 'false';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return false when object is null and query is "null"', () => {
+      const object = null;
+      const query = 'null';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return true when query is an empty string', () => {
+      const object = { name: 'John', age: 30 };
+      const query = '';
+
+      expect(fullTextSearch(object, query)).to.be.true;
+    });
+
+    it('should return false when object is an empty object', () => {
+      const object = {};
+      const query = 'John';
+
+      expect(fullTextSearch(object, query)).to.be.false;
+    });
+
+    it('should return false when object is an empty array', () => {
+      const object = [];
+      const query = 'John';
+
+      expect(fullTextSearch(object, query)).to.be.false;
     });
   });
 });

--- a/packages/desktop/test/data/mock-envs/crud.json
+++ b/packages/desktop/test/data/mock-envs/crud.json
@@ -139,6 +139,13 @@
       "name": "arraystring",
       "documentation": "",
       "value": "[\"aaa\",\"bbb\",\"ccc\"]"
+    },
+    {
+      "uuid": "0be1d384-bf8c-467c-b454-fa72aafe0f51",
+      "id": "abc5",
+      "name": "search",
+      "documentation": "",
+      "value": "[\n  {\n    \"id\": 1,\n    \"username\": \"peter\",\n    \"age\": 30,\n    \"address\": { \"city\": \"New York\" },\n    \"hobbies\": [\"reading\", \"swimming\"]\n  },\n  {\n    \"id\": 2,\n    \"username\": \"alberto\",\n    \"age\": 35,\n    \"address\": { \"city\": \"Los Angeles\" },\n    \"hobbies\": [\"dancing\", \"coding\"]\n  },\n  {\n    \"id\": 3,\n    \"username\": \"marta\",\n    \"age\": 25,\n    \"address\": { \"city\": \"Chicago\" },\n    \"hobbies\": [\"reading\", \"dancing\"]\n  },\n  {\n    \"id\": 4,\n    \"username\": \"mary\",\n    \"age\": 40,\n    \"address\": { \"city\": \"San Francisco\" },\n    \"hobbies\": [\"swimming\", \"coding\"]\n  },\n  {\n    \"id\": 5,\n    \"username\": \"john\",\n    \"age\": 30,\n    \"address\": { \"city\": \"New York\" },\n    \"hobbies\": [\"reading\", \"swimming\"]\n  },\n  {\n    \"id\": 6,\n    \"username\": \"douglas\",\n    \"age\": 35,\n    \"address\": { \"city\": \"Los Angeles\" },\n    \"hobbies\": [\"dancing\", \"coding\"]\n  },\n  {\n    \"id\": 7,\n    \"username\": \"paul\",\n    \"age\": 25,\n    \"address\": { \"city\": \"Chicago\" },\n    \"hobbies\": [\"reading\", \"dancing\"]\n  },\n  {\n    \"id\": 8,\n    \"username\": \"paula\",\n    \"age\": 40,\n    \"address\": { \"city\": \"San Francisco\" },\n    \"hobbies\": [\"swimming\", \"coding\"]\n  },\n  {\n    \"id\": 9,\n    \"username\": \"theresa\",\n    \"age\": 30,\n    \"address\": { \"city\": \"New York\" },\n    \"hobbies\": [\"reading\", \"swimming\"]\n  },\n  {\n    \"id\": 10,\n    \"username\": \"cinderella\",\n    \"age\": 35,\n    \"address\": { \"city\": \"Los Angeles\" },\n    \"hobbies\": [\"dancing\", \"coding\"]\n  },\n  {\n    \"id\": 11,\n    \"username\": \"laura\",\n    \"age\": 25,\n    \"address\": { \"city\": \"Chicago\" },\n    \"hobbies\": [\"reading\", \"dancing\"]\n  }\n]"
     }
   ],
   "folders": [],

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -13,7 +13,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -63,7 +67,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: /\[\{"id":1,"name":"john"\},\{"id":"[a-z0-9-]{36}"\}\]/,
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -88,7 +96,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: /\[\{"id":1,"name":"john"\},\{"id":"[a-z0-9-]{36}"\}\]/,
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -113,7 +125,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: /\[\{"id":1,"name":"john"\},\{"id":"[a-z0-9-]{36}","test":"hello"\}\]/,
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -138,7 +154,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"},{"id":"idtest","test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -163,7 +183,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"},"teststring"]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -188,7 +212,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"},"test,string"]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -225,7 +253,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -250,7 +282,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -275,7 +311,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -300,7 +340,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":"123","test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -325,7 +369,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -350,7 +398,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -375,7 +427,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":"123","test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -413,7 +469,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -438,7 +498,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john","test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -463,7 +527,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -488,7 +556,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '1',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -513,7 +585,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"name":"john"},{"id":2,"test":"hello"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '2',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -550,7 +626,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '0',
+          'x-filtered-count': '0'
+        }
       }
     }
   ],
@@ -586,7 +666,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter"},{"id":2,"username":"alberto"},{"id":3,"username":"marta"},{"id":4,"username":"mary"},{"id":5,"username":"john"},{"id":6,"username":"douglas"},{"id":7,"username":"paul"},{"id":8,"username":"paula"},{"id":9,"username":"theresa"},{"id":10,"username":"cinderella"},{"id":11,"username":"laura"}]',
-        headers: { 'content-type': 'application/json' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -596,7 +680,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter"},{"id":2,"username":"alberto"},{"id":3,"username":"marta"},{"id":4,"username":"mary"},{"id":5,"username":"john"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -606,7 +694,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter"},{"id":2,"username":"alberto"},{"id":3,"username":"marta"},{"id":4,"username":"mary"},{"id":5,"username":"john"},{"id":6,"username":"douglas"},{"id":7,"username":"paul"},{"id":8,"username":"paula"},{"id":9,"username":"theresa"},{"id":10,"username":"cinderella"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -616,7 +708,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":6,"username":"douglas"},{"id":7,"username":"paul"},{"id":8,"username":"paula"},{"id":9,"username":"theresa"},{"id":10,"username":"cinderella"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -627,7 +723,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":3,"username":"marta"},{"id":4,"username":"mary"},{"id":7,"username":"paul"},{"id":8,"username":"paula"},{"id":1,"username":"peter"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -638,7 +738,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":3,"username":"marta"},{"id":11,"username":"laura"},{"id":5,"username":"john"},{"id":6,"username":"douglas"},{"id":10,"username":"cinderella"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -649,7 +753,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":6,"username":"douglas"},{"id":7,"username":"paul"},{"id":8,"username":"paula"},{"id":9,"username":"theresa"},{"id":10,"username":"cinderella"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     },
     {
@@ -659,7 +767,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":6,"username":"douglas"},{"id":5,"username":"john"},{"id":4,"username":"mary"},{"id":3,"username":"marta"},{"id":2,"username":"alberto"}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '11'
+        }
       }
     }
   ],
@@ -1110,7 +1222,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -1123,7 +1239,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '2'
+        }
       }
     }
   ],
@@ -1136,7 +1256,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":9,"username":"theresa","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
       }
     }
   ],
@@ -1148,7 +1272,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":9,"username":"theresa","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '5'
+        }
       }
     }
   ],
@@ -1163,8 +1291,8 @@ const jsonArrayTestGroups: HttpCall[][] = [
         body: '[{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":3,"username":"marta","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
         headers: {
           'content-type': 'application/json',
-          'x-filtered-count': '6',
-          'x-total-count': '11'
+          'x-total-count': '11',
+          'x-filtered-count': '6'
         }
       }
     }
@@ -1177,7 +1305,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '0'
+        }
       }
     }
   ],
@@ -1189,7 +1321,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -1201,7 +1337,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
       }
     }
   ],
@@ -1215,8 +1355,8 @@ const jsonArrayTestGroups: HttpCall[][] = [
         body: '[{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
         headers: {
           'content-type': 'application/json',
-          'x-filtered-count': '3',
-          'x-total-count': '11'
+          'x-total-count': '11',
+          'x-filtered-count': '3'
         }
       }
     }
@@ -1229,7 +1369,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -1243,7 +1387,8 @@ const jsonArrayTestGroups: HttpCall[][] = [
         body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
         headers: {
           'content-type': 'application/json',
-          'x-total-count': '11'
+          'x-total-count': '11',
+          'x-filtered-count': '11'
         }
       }
     }
@@ -1256,7 +1401,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '1'
+        }
       }
     }
   ],
@@ -1268,7 +1417,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '[{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":3,"username":"marta","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '4'
+        }
       }
     }
   ],
@@ -1280,7 +1433,11 @@ const jsonArrayTestGroups: HttpCall[][] = [
       testedResponse: {
         status: 200,
         body: '["aaa"]',
-        headers: { 'content-type': 'application/json', 'x-total-count': '3' }
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '3',
+          'x-filtered-count': '1'
+        }
       }
     }
   ]

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -1587,6 +1587,22 @@ const jsonArrayTestGroups: HttpCall[][] = [
   ],
   [
     {
+      description: 'Filter - like operator (regex)',
+      path: '/search?id_like=^(1|4|7)$',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
+      }
+    }
+  ],
+  [
+    {
       description: 'Filter - nested properties access',
       path: '/search?address.city_eq=New%20York',
       method: 'GET',

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -1603,6 +1603,22 @@ const jsonArrayTestGroups: HttpCall[][] = [
   ],
   [
     {
+      description: 'Filter - filter on primitive array',
+      path: '/primitivearray?_gte=b',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '["bbb","ccc"]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '3',
+          'x-filtered-count': '2'
+        }
+      }
+    }
+  ],
+  [
+    {
       description: 'Filter + Search + Sort + Pagination',
       path: '/search?search=york&age_gt=25&sort=username&limit=1',
       method: 'GET',

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -1101,6 +1101,188 @@ const jsonArrayTestGroups: HttpCall[][] = [
         body: ''
       }
     }
+  ],
+  [
+    {
+      description: 'Search - get all with search query "peter"',
+      path: '/search?search=peter',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description:
+        'Search - get all with search query "paul" and order by "username" descending',
+      path: '/search?search=paul&sort=username&order=desc',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description:
+        'Search - get all with search query "New York" in nested object',
+      path: '/search?search=New%20York',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":9,"username":"theresa","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - get all with search query "swimming" in array',
+      path: '/search?search=swimming',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":9,"username":"theresa","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description:
+        'Search - get all with search query "dancing" in array and paginate',
+      path: '/search?search=dancing&page=1&limit=2',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":3,"username":"marta","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-filtered-count': '6',
+          'x-total-count': '11'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - no match',
+      path: '/search?search=nonexistent',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - partial match',
+      path: '/search?search=pet',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - matches multiple records for different reasons',
+      path: '/search?search=ra',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - matches multiple records with pagination',
+      path: '/search?search=ra&page=1&limit=1',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-filtered-count': '3',
+          'x-total-count': '11'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - case insensitive',
+      path: '/search?search=PETER',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - empty string',
+      path: '/search?search=&limit=1',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - filter on numbers',
+      path: '/search?search=8',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - filter on partial numbers',
+      path: '/search?search=2',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":3,"username":"marta","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '11' }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Search - filter on primitive array',
+      path: '/primitivearray?search=a',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '["aaa"]',
+        headers: { 'content-type': 'application/json', 'x-total-count': '3' }
+      }
+    }
   ]
 ];
 
@@ -1155,6 +1337,11 @@ describe('CRUD endpoints', () => {
     await routes.setPath('primitivearray');
     await routes.openDataBucketMenu();
     await routes.selectDataBucket(4);
+
+    await routes.addCRUDRoute();
+    await routes.setPath('search');
+    await routes.openDataBucketMenu();
+    await routes.selectDataBucket(5);
   });
 
   it('should start the environment', async () => {

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -1440,6 +1440,182 @@ const jsonArrayTestGroups: HttpCall[][] = [
         }
       }
     }
+  ],
+  [
+    {
+      description: 'Filter - equal operator',
+      path: '/search?username_eq=peter',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '1'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - not equal operator',
+      path: '/search?age_ne=25&limit=2',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '8'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - greater than operator',
+      path: '/search?age_gt=35',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '2'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - greater than or equal operator',
+      path: '/search?age_gte=35',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":2,"username":"alberto","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":4,"username":"mary","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":6,"username":"douglas","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":10,"username":"cinderella","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '5'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - less than operator',
+      path: '/search?age_lt=5',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '0'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - less than or equal operator',
+      path: '/search?age_lte=25',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":3,"username":"marta","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - like operator',
+      path: '/search?username_like=la',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":6,"username":"douglas","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":10,"username":"cinderella","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]},{"id":11,"username":"laura","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '4'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - start operator',
+      path: '/search?username_start=p',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":7,"username":"paul","age":25,"address":{"city":"Chicago"},"hobbies":["reading","dancing"]},{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - start operator',
+      path: '/search?username_end=la',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":8,"username":"paula","age":40,"address":{"city":"San Francisco"},"hobbies":["swimming","coding"]},{"id":10,"username":"cinderella","age":35,"address":{"city":"Los Angeles"},"hobbies":["dancing","coding"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '2'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter - nested properties access',
+      path: '/search?address.city_eq=New%20York',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":1,"username":"peter","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]},{"id":9,"username":"theresa","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
+      }
+    }
+  ],
+  [
+    {
+      description: 'Filter + Search + Sort + Pagination',
+      path: '/search?search=york&age_gt=25&sort=username&limit=1',
+      method: 'GET',
+      testedResponse: {
+        status: 200,
+        body: '[{"id":5,"username":"john","age":30,"address":{"city":"New York"},"hobbies":["reading","swimming"]}]',
+        headers: {
+          'content-type': 'application/json',
+          'x-total-count': '11',
+          'x-filtered-count': '3'
+        }
+      }
+    }
   ]
 ];
 


### PR DESCRIPTION
Adds **searching and filtering** functionality to CRUD routes using query params

# Filtering

Adds the ability to use query parameters in the form of `[property]_[operator]`. For instance, if you want to filter an array of objects by their `status` property, you can use:

```
GET /path?status_eq=success
```

With this PR, the following operators are introduced:

| Operator | Description                                   | Example             |
| -------- | --------------------------------------------- | ------------------- |
| `eq`     | Filters by equality                           | `status_eq=success` |
| `ne`     | Filters by inequality                         | `status_ne=error`   |
| `gt`     | Filters by greater                            | `price_gt=10`       |
| `gte`    | Filters by greater or equal                   | `price_gte=10`      |
| `lt`     | Filters by lower                              | `price_lt=10`       |
| `lte`    | Filters by lower or equal                     | `price_lte=10`      |
| `like`   | Filters by partial match \*                   | `name_like=ohn do`  |
| `start`  | Filters properties that start with a value \* | `name_start=john`   |
| `end`    | Filters properties that end with a value \*   | `name_end=doe`      |

\* Case insensitive

- filters work on every primitive value (strings, numbers, booleans, etc.), so you can filter by `true` or `false` values, or even `null` values, e.g. `is_active_eq=true`
- works on arrays of primitives, in which case using `_[operator]` is enough, e.g. `_gte=10`
- supports nesting: `user.email_end=@example.com`
- `like`, `start` and `end` have support for regex out of the box

# Searching

Adds the ability to search an array via the `search` query parameter. Search is a special kind of filter that will look for a partial match in any values (with nesting) in the array. For instance, if you want to search for `john` in an array of users, you can use:

```
GET /path?search=john
```

- works on arrays of primitives (strings, numbers, etc.)

## Meta data

- Adds a new `X-Filtered-Count` header to the response, to indicate the number of items after filtering (not taking into account pagination)

**Checklist**

- [x] Common-Server automated tests added (@mockoon/common-server)
- [x] Desktop automated tests added (@mockoon/desktop)

Closes #1047
