### PR TITLE
Allow objects as argument to faker functions

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/faker-wrapper.ts
+++ b/packages/commons-server/src/libs/templating-helpers/faker-wrapper.ts
@@ -1,6 +1,6 @@
 import { HelperOptions } from 'handlebars';
 import { localFaker as faker, safeFakerReturn } from '../../libs/faker';
-import { IsEmpty, fromSafeString } from '../utils';
+import { IsEmpty, fromSafeString, objectFromSafeString } from '../utils';
 
 export const FakerWrapper = {
   faker: function (...args: any[]) {
@@ -48,7 +48,20 @@ export const FakerWrapper = {
     }
 
     const fakerFunction = faker[fakerPrimaryMethod][fakerSecondaryMethod];
-    const fakerArgs = args.slice(1, args.length - 1);
+    const fakerArgsRaw = args.slice(1, args.length - 1);
+    const fakerArgs: any[] = [];
+    fakerArgsRaw.forEach((arg) => {
+      if (typeof arg === 'string' && arg.startsWith('{') && arg.endsWith('}')) {
+        const objectArg = objectFromSafeString(arg);
+        if (objectArg === null) {
+          throw new Error(`Error in parsing object argument ${arg}`);
+        } else {
+          fakerArgs.push(objectArg);
+        }
+      } else {
+        fakerArgs.push(arg);
+      }
+    });
 
     // push hbs named parameters (https://handlebarsjs.com/guide/block-helpers.html#hash-arguments) to Faker
     if (!IsEmpty(hbsOptions.hash)) {

--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -219,6 +219,26 @@ export const numberFromSafeString = (text: string | SafeString) => {
 };
 
 /**
+ *
+ * @param text
+ * @returns object | null
+ */
+export const objectFromSafeString = (text: string | SafeString) => {
+  const parsedText = text instanceof SafeString ? text.toString() : text;
+  // Remove any escape slashes used to escape double-quotes or single-quotes
+  // (Check test case).
+  // Surround all object keys with double-quotes to make it valid JSON text.
+  const objectText = parsedText
+    .replace(/\\/g, '')
+    .replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2": ');
+  try {
+    return JSON.parse(objectText);
+  } catch (e) {
+    return null;
+  }
+};
+
+/**
  * Resolve a file path relatively to the current environment folder if provided
  */
 export const resolvePathFromEnvironment = (

--- a/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/faker-wrapper.spec.ts
@@ -160,4 +160,16 @@ describe('Template parser: Faker wrapper', () => {
     );
     expect(parseResult).to.be.equal('2');
   });
+
+  it('should allow objects as argument to faker function', () => {
+    const parseResult = TemplateParser(
+      false,
+      '{{faker \'string.alpha\' \'{ length: 5, casing: "upper", exclude: ["A"] }\' }}',
+      {} as any,
+      [],
+      {},
+      {} as any
+    );
+    expect(parseResult).to.be.equal('KFKJR');
+  });
 });


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

Allow objects as arguments for faker functions as below.

```
"{{ faker 'string.alpha' '{length: {min: 4, max: 10}, casing: \"upper\", exclude: [\"A\"]}' }}"
```

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)
- [x] commons server automated tests added (@mockoon/commons-server)

<!-- Link to the original issue -->

Closes #1218 
