### PR TITLE
Update app close options for macOS

### DIFF
--- a/packages/desktop/src/main/app.ts
+++ b/packages/desktop/src/main/app.ts
@@ -16,6 +16,7 @@ setPaths();
 createMainLogger();
 
 let mainWindow: BrowserWindow;
+let isQuitting = false;
 
 // try getting a lock to ensure only one instance of the application is launched
 let appLock = app.requestSingleInstanceLock();
@@ -25,8 +26,8 @@ if (IS_DEV) {
   appLock = true;
 }
 
-const initApp = () => {
-  mainWindow = initMainWindow();
+const initApp = (showSplash = true) => {
+  mainWindow = initMainWindow(showSplash);
   initIPCListeners(mainWindow);
 
   if (IS_DEV) {
@@ -68,9 +69,13 @@ if (!appLock) {
       // On macOS it's common to re-create a window in the app when the
       // dock icon is clicked and there are no other windows open.
       if (BrowserWindow.getAllWindows().length === 0) {
-        initApp();
+        initApp(false);
       }
     });
+  });
+
+  app.on('before-quit', () => {
+    isQuitting = true;
   });
 
   // Quit when all windows are closed.
@@ -81,7 +86,7 @@ if (!appLock) {
 
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q (except when running tests)
-    if (process.platform !== 'darwin' || IS_TESTING) {
+    if (isQuitting || process.platform !== 'darwin' || IS_TESTING) {
       app.quit();
     }
   });

--- a/packages/desktop/src/main/libs/main-window.ts
+++ b/packages/desktop/src/main/libs/main-window.ts
@@ -28,11 +28,11 @@ export const saveOpenUrlArgs = (url: string[]) => {
 
 export const getMainWindow = () => mainWindow;
 
-export const initMainWindow = () => {
+export const initMainWindow = (showSplash = true) => {
   let splashScreen: BrowserWindow;
 
   // only show the splashscreen when not running the tests
-  if (!IS_TESTING) {
+  if (!IS_TESTING && showSplash) {
     splashScreen = createSplashScreen();
   }
 

--- a/packages/desktop/src/main/libs/menu.ts
+++ b/packages/desktop/src/main/libs/menu.ts
@@ -78,7 +78,8 @@ export const createMenu = (mainWindow: BrowserWindow): Menu => {
     menu[0].submenu.push(
       { label: 'Hide', role: 'hide' },
       { role: 'hideOthers' },
-      { type: 'separator' }
+      { type: 'separator' },
+      { label: 'Close window', accelerator: 'CmdOrCtrl+W', role: 'close' }
     );
   }
 


### PR DESCRIPTION
- Add a new Close window option to enable cmd+w shortcut
- Make cmd+q and dock right-click->quit to permanently quit the application

Closes 1097

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
