### PR TITLE
Add support for vendor specific JSON content types

### DIFF
--- a/packages/commons-server/src/constants/common.constants.ts
+++ b/packages/commons-server/src/constants/common.constants.ts
@@ -4,8 +4,13 @@ export const ParsedXMLBodyMimeTypes = [
   'text/xml'
 ];
 
-export const ParsedBodyMimeTypes = [
+export const ParsedJSONBodyMimeTypes = [
   'application/json',
+  /application\/.*\+json/i
+];
+
+export const ParsedBodyMimeTypes = [
+  ...ParsedJSONBodyMimeTypes,
   'application/x-www-form-urlencoded',
   'multipart/form-data',
   ...ParsedXMLBodyMimeTypes

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -41,7 +41,10 @@ import { SecureContextOptions } from 'tls';
 import TypedEmitter from 'typed-emitter';
 import { format } from 'util';
 import { xml2js } from 'xml-js';
-import { ParsedXMLBodyMimeTypes } from '../../constants/common.constants';
+import {
+  ParsedJSONBodyMimeTypes,
+  ParsedXMLBodyMimeTypes
+} from '../../constants/common.constants';
 import { ServerMessages } from '../../constants/server-messages.constants';
 import { DefaultTLSOptions } from '../../constants/ssl.constants';
 import { SetFakerLocale, SetFakerSeed } from '../faker';
@@ -303,7 +306,12 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
 
       try {
         if (requestContentType) {
-          if (requestContentType.includes('application/json')) {
+          if (
+            stringIncludesArrayItems(
+              ParsedJSONBodyMimeTypes,
+              requestContentType
+            )
+          ) {
             request.body = JSON.parse(request.stringBody);
             next();
           } else if (

--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -260,9 +260,12 @@ export const resolvePathFromEnvironment = (
  * @returns
  */
 export const stringIncludesArrayItems = (
-  array: string[],
+  array: (string | RegExp)[],
   str: string
-): boolean => array.some((item) => str.includes(item));
+): boolean =>
+  array.some((item) =>
+    item instanceof RegExp ? item.test(str) : str.includes(item)
+  );
 
 /**
  * Convert an object path (for the object-path lib) containing escaped dots '\.'


### PR DESCRIPTION
Some clients uses vendor specific JSON Content-Type like `application/vnd.xxxxxxx+json`. This add support for these types in the request body parsing and rules interpreter. Closes #1269

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
