### PR TITLE
Remove CLI's chalk usage

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -11,7 +11,6 @@ import {
   listenServerEvents
 } from '@mockoon/commons-server';
 import { Command, Flags } from '@oclif/core';
-import { red as chalkRed } from 'chalk';
 import { join } from 'path';
 import { format } from 'util';
 import { Config } from '../config';
@@ -191,7 +190,8 @@ export default class Start extends Command {
 
       // Cannot use this.error() as Oclif does not catch it (it seems to be lost due to the async nature of Node.js http server.listen errors).
       if (exitErrors.includes(errorCode)) {
-        this.log(`${chalkRed(' »')}   Error: ${errorMessage}`);
+        // red "»" character
+        this.log(`\x1b[31m»\x1b[0m   Error: ${errorMessage}`);
         process.exit(2);
       }
     });


### PR DESCRIPTION
Due to bad usage of chalk lib (without listing it as a dependency, or peerDep), the CLI could crash when run in a project using an incompatible version (like v5 which is ESM only).

Closes #1276

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
