### PR TITLE
Fix editable element component not propagating blur event

### DIFF
--- a/packages/desktop/src/renderer/app/components/editable-element/editable-element.component.ts
+++ b/packages/desktop/src/renderer/app/components/editable-element/editable-element.component.ts
@@ -109,14 +109,17 @@ export class EditableElementComponent implements ControlValueAccessor {
   }
 
   public save() {
+    // always set editing state to false and propagate to the parent
+    this.editChange.emit(false);
+    this.edit = false;
+
     // Do not save if the text is the same
     if (this._text === this.data.value) {
       return;
     }
 
+    // save the new value and propagate to the parent
     this.text = this.data.value;
     this.onChange(this.data.value);
-    this.edit = false;
-    this.editChange.emit(false);
   }
 }

--- a/packages/desktop/src/renderer/styles/boostrap-overrides.scss
+++ b/packages/desktop/src/renderer/styles/boostrap-overrides.scss
@@ -71,9 +71,6 @@
   max-height: 65vh;
 }
 .form-control {
-  letter-spacing: 0.02rem;
-  background-clip: border-box;
-
   &:disabled,
   &[readonly] {
     color: $text-muted;


### PR DESCRIPTION
Since last patch, input was not hidden after a click outside of the input Also remove some very old CSS causing letter blinking Closes #1279

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
