### PR TITLE
Use JSON.Stringify in `someOf` helper

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/helpers/someOf.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/someOf.ts
@@ -6,14 +6,14 @@ const someOf = function (
   itemList: string[],
   min: number,
   max: number,
-  asArray = false
+  stringify = false
 ) {
   const randomItems = itemList
     .sort(() => 0.5 - Math.random())
     .slice(0, RandomInt(min, max));
 
-  if (asArray === true) {
-    return `["${randomItems.join('","')}"]`;
+  if (stringify === true) {
+    return JSON.stringify(randomItems);
   }
 
   return randomItems;

--- a/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
+++ b/packages/commons-server/test/suites/templating-helpers/helpers.spec.ts
@@ -1296,6 +1296,30 @@ describe('Template parser', () => {
       expect(countSeparators).is.least(0);
       expect(countSeparators).is.most(2);
     });
+
+    it('should return 1 element stringified', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{someOf (array 'value1') 1 1 true}}",
+        {} as any,
+        [],
+        {},
+        {} as any
+      );
+      expect(parseResult).to.equal('[&quot;value1&quot;]');
+    });
+
+    it('should return 0 element stringified', () => {
+      const parseResult = TemplateParser(
+        false,
+        "{{someOf (array 'value1') 0 0 true}}",
+        {} as any,
+        [],
+        {},
+        {} as any
+      );
+      expect(parseResult).to.equal('[]');
+    });
   });
 
   describe('Helper: len', () => {


### PR DESCRIPTION
Use JSON.Stringify in `someOf` helper instead of custom thing as it would return an array with one empty string when there is no element instead of just an empty array. Closes #1289

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
