### PR TITLE
Support for OpenAPI schema allOf, oneOf, etc.

### DIFF
--- a/packages/commons-server/src/libs/openapi-converter.ts
+++ b/packages/commons-server/src/libs/openapi-converter.ts
@@ -593,18 +593,17 @@ export class OpenAPIConverter {
         return schema.default;
       }
 
-      let schemaToBuild = schema;
+      const schemaToBuild = schema;
 
       // check if we have an array of schemas, and take first item
-      ['allOf', 'oneOf', 'anyOf'].forEach((propertyName) => {
+      for (const propertyName of ['allOf', 'oneOf', 'anyOf']) {
         if (
           schema.hasOwnProperty(propertyName) &&
           schema[propertyName].length > 0
         ) {
-          type = schema[propertyName][0].type;
-          schemaToBuild = schema[propertyName][0];
+          return this.generateSchema(schema[propertyName][0]);
         }
-      });
+      }
 
       // sometimes we have no type but only 'properties' (=object)
       if (

--- a/packages/desktop/test/data/res/import-openapi/references/custom-schema-v3.json
+++ b/packages/desktop/test/data/res/import-openapi/references/custom-schema-v3.json
@@ -1,22 +1,22 @@
 {
-  "uuid": "0cd3abf9-2fbf-404e-a9d0-f0af4cd0d83c",
+  "uuid": "f2fe8335-4c39-424d-a386-9e3ebe61bded",
   "lastMigration": 32,
   "name": "Sample v3 schema",
   "endpointPrefix": "api",
   "latency": 0,
-  "port": 3005,
+  "port": 3000,
   "hostname": "",
   "folders": [],
   "routes": [
     {
-      "uuid": "047eb7da-7622-45ea-bcf0-665f37df028a",
+      "uuid": "ce0a82f1-c9ec-4f53-8200-7257bfb1de35",
       "type": "http",
       "documentation": "",
       "method": "get",
       "endpoint": "endpoint",
       "responses": [
         {
-          "uuid": "97d9a7d8-71b3-4878-ae80-e4d9d027611e",
+          "uuid": "8c619433-fc0a-416e-8dd9-5c642d4effef",
           "body": "[\n  {\n    \"id\": {{faker 'number.int' max=99999}},\n    \"order\": {{faker 'number.float'}},\n    \"quantity\": {{faker 'number.float'}},\n    \"datetime\": \"{{faker 'date.recent' 365}}\",\n    \"date\": \"{{date '2019' (now) 'yyyy-MM-dd'}}\",\n    \"age\": \"32\",\n    \"email\": \"{{faker 'internet.email'}}\",\n    \"uuid\": \"{{faker 'string.uuid'}}\",\n    \"tags\": [\n      \"\"\n    ],\n    \"status\": \"{{oneOf (array 'enum1' 'enum2' 'enum3')}}\",\n    \"inProgress\": {{faker 'datatype.boolean'}},\n    \"complete\": true,\n    \"categories\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"allOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"oneOfArray\": [\n      \"\"\n    ],\n    \"anyOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ]\n  }\n]",
           "latency": 0,
           "statusCode": 200,
@@ -59,14 +59,14 @@
       "responseMode": null
     },
     {
-      "uuid": "a0a5e12a-33a2-4583-a85d-e1521969f327",
+      "uuid": "29027351-aabf-41cc-a74b-b66d20d3fb64",
       "type": "http",
       "documentation": "",
       "method": "get",
       "endpoint": "endpoint2",
       "responses": [
         {
-          "uuid": "bc0be1d1-75cf-4ef6-9c74-7a107f57d140",
+          "uuid": "02f17079-62aa-434e-905c-707c1687e737",
           "body": "[\n  {\n    \"id\": {{faker 'number.int' max=99999}},\n    \"order\": {{faker 'number.float'}},\n    \"quantity\": {{faker 'number.float'}},\n    \"datetime\": \"{{faker 'date.recent' 365}}\",\n    \"date\": \"{{date '2019' (now) 'yyyy-MM-dd'}}\",\n    \"age\": \"32\",\n    \"email\": \"{{faker 'internet.email'}}\",\n    \"uuid\": \"{{faker 'string.uuid'}}\",\n    \"tags\": [\n      \"\"\n    ],\n    \"status\": \"{{oneOf (array 'enum1' 'enum2' 'enum3')}}\",\n    \"inProgress\": {{faker 'datatype.boolean'}},\n    \"complete\": true,\n    \"categories\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"allOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"oneOfArray\": [\n      \"\"\n    ],\n    \"anyOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ]\n  }\n]",
           "latency": 0,
           "statusCode": 200,
@@ -93,14 +93,14 @@
       "responseMode": null
     },
     {
-      "uuid": "d4447430-7f55-43d9-83f1-18a201ff41d6",
+      "uuid": "0521d3c4-9fc9-4ef2-bd4c-821c007a41b4",
       "type": "http",
       "documentation": "",
       "method": "get",
       "endpoint": "endpoint3",
       "responses": [
         {
-          "uuid": "208516a8-9057-484f-9c57-73dd6626d2c4",
+          "uuid": "b53a86d3-0a30-437c-b8ef-20485a675bbe",
           "body": "[\n  {\n    \"id\": {{faker 'number.int' max=99999}},\n    \"order\": {{faker 'number.float'}},\n    \"quantity\": {{faker 'number.float'}},\n    \"datetime\": \"{{faker 'date.recent' 365}}\",\n    \"date\": \"{{date '2019' (now) 'yyyy-MM-dd'}}\",\n    \"age\": \"32\",\n    \"email\": \"{{faker 'internet.email'}}\",\n    \"uuid\": \"{{faker 'string.uuid'}}\",\n    \"tags\": [\n      \"\"\n    ],\n    \"status\": \"{{oneOf (array 'enum1' 'enum2' 'enum3')}}\",\n    \"inProgress\": {{faker 'datatype.boolean'}},\n    \"complete\": true,\n    \"categories\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"allOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ],\n    \"oneOfArray\": [\n      \"\"\n    ],\n    \"anyOfArray\": [\n      {\n        \"name\": \"\"\n      }\n    ]\n  }\n]",
           "latency": 0,
           "statusCode": 200,
@@ -125,20 +125,58 @@
         }
       ],
       "responseMode": null
+    },
+    {
+      "uuid": "c7a22ea6-25b0-4adc-ac8e-e70f56e5e35f",
+      "type": "http",
+      "documentation": "Returns a model.",
+      "method": "get",
+      "endpoint": "model",
+      "responses": [
+        {
+          "uuid": "ef8a8de2-1b1e-4820-af55-3692fbeb56bc",
+          "body": "{\n  \"name\": \"custom_name\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "A model with a name",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
     }
   ],
   "rootChildren": [
     {
       "type": "route",
-      "uuid": "047eb7da-7622-45ea-bcf0-665f37df028a"
+      "uuid": "ce0a82f1-c9ec-4f53-8200-7257bfb1de35"
     },
     {
       "type": "route",
-      "uuid": "a0a5e12a-33a2-4583-a85d-e1521969f327"
+      "uuid": "29027351-aabf-41cc-a74b-b66d20d3fb64"
     },
     {
       "type": "route",
-      "uuid": "d4447430-7f55-43d9-83f1-18a201ff41d6"
+      "uuid": "0521d3c4-9fc9-4ef2-bd4c-821c007a41b4"
+    },
+    {
+      "type": "route",
+      "uuid": "c7a22ea6-25b0-4adc-ac8e-e70f56e5e35f"
     }
   ],
   "proxyMode": false,

--- a/packages/desktop/test/data/res/import-openapi/samples/custom-schema-v3.yaml
+++ b/packages/desktop/test/data/res/import-openapi/samples/custom-schema-v3.yaml
@@ -69,6 +69,19 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/SchemaObject"
+  /model:
+    get:
+      summary: Returns a model.
+      description: Some description.
+      responses:
+        "200":
+          description: A model with a name
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Model"
+
 components:
   schemas:
     SchemaObject:
@@ -143,3 +156,11 @@ components:
           type: "string"
     Tag:
       type: "string"
+
+    Model:
+      type: object
+      properties:
+        name:
+          type: string
+      example:
+        name: custom_name


### PR DESCRIPTION
Fix `example`, `default`, etc not being picked up when `schema` contains `allof`, `oneOf` or `anyOf`. Closes #948

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] data migration automated tests added (@mockoon/commons)
- [ ] CLI automated tests added (@mockoon/cli)
- [ ] desktop automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
