### PR TITLE
Overwrite `source` and `pkgrel` in aur package on every package release

### DIFF
--- a/packages/desktop/scripts/aur-version-bump/README.md
+++ b/packages/desktop/scripts/aur-version-bump/README.md
@@ -7,4 +7,6 @@ Set the git configuration to your git email and name in der Dockerfile (line 15,
 If you want to use another ssh key than default you have to pass its value.
 
 # Run:
-`docker run --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent mockoon-bin-version-bump "<VERSION>"`
+`docker run --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent mockoon-bin-version-bump "<mockoon-version>" "<aur-revision>"`
+
+Note on the `aur-revision`, typically simply set this to "1", but if you need to do fixes to the package itself without any update to the mockoon debian file, simply increment this number. On the next mockoon update, you can reset it to "1" again.

--- a/packages/desktop/scripts/aur-version-bump/bump
+++ b/packages/desktop/scripts/aur-version-bump/bump
@@ -7,11 +7,19 @@ git pull
 echo "Setting pkgver to $1"
 sed -i "/pkgver=/c\pkgver=$1" PKGBUILD
 
-echo "Downloading debian package (https://github.com/mockoon/mockoon/releases/download/v$1/mockoon-$1.amd64.deb) for md5sum"
-md5sum=`curl -sL "https://github.com/mockoon/mockoon/releases/download/v$1/mockoon-$1.amd64.deb" | md5sum | cut -d ' ' -f 1`
+echo "Setting pkgrel to $2"
+sed -i "/pkgrel=/c\pkgrel=$2" PKGBUILD
+
+source="https://github.com/mockoon/mockoon/releases/download/v$1/mockoon-$1.amd64.deb"
+
+echo "Downloading debian package ($source) for md5sum"
+md5sum=`curl -sL "$source" | md5sum | cut -d ' ' -f 1`
 
 echo "Setting md5sums to $md5sum"
 sed -i "/md5sums=/c\md5sums=('$md5sum')" PKGBUILD
+
+echo "Setting source to $source"
+sed -i "/source=/c\source=('$source')" PKGBUILD
 
 echo "Generating .SRCINFO"
 sudo -u build-user makepkg --printsrcinfo > .SRCINFO


### PR DESCRIPTION
Hi, as just discussed via email, here is the PR that addresses the problem with the AUR package update:

The issue was that the initial script had never assumed that the `source` actually changes, aside from the version of course. So once you updated the url with `amd64`, it was only really changed for the checksum generation, but not actually for the `source` field itself. See specifically the line [here](https://github.com/mockoon/mockoon/compare/main...Spissable:mockoon:fix-aur-version-bump?expand=1#diff-38db9d1bd110ea7f464de5a9ef6978ce085254bf68c2cfe1bc3ab6485209ccafR22) which overwrites the `source` field in the `PKGBUILD`.


As a little QoL, I also added the `pkgrel` as a param here. Apparently we were forever stuck with the number `2`, which while not harmful, it wasn't quite right, plus for cases like the one mentioned here, it was nice for me to simply increment it to `3` to indicate that there was an AUR package update addressing an issue, without an actual mockoon update.

Note that the script doesn't need to be run right now, as I already took care of it:
![image](https://github.com/mockoon/mockoon/assets/35728419/dccf1995-77ff-47e3-bde3-2a58312df682)



