### PR TITLE
Issue #1365 - add warning when json is invalid

### DIFF
--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
@@ -496,7 +496,13 @@ export class EnvironmentRoutesComponent implements OnInit, OnDestroy {
             )
           );
       } catch (e) {
-        // ignore any errors with parsing / stringifying the JSON
+        this.uiService
+          .showConfirmDialog({
+            title: 'Error white parsing JSON',
+            text: 'The JSON body could not be parsed.',
+            subIcon: 'warning',
+            subIconClass: 'text-warning'
+          });
       }
     }
   }

--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.ts
@@ -496,13 +496,12 @@ export class EnvironmentRoutesComponent implements OnInit, OnDestroy {
             )
           );
       } catch (e) {
-        this.uiService
-          .showConfirmDialog({
-            title: 'Error white parsing JSON',
-            text: 'The JSON body could not be parsed.',
-            subIcon: 'warning',
-            subIconClass: 'text-warning'
-          });
+        this.uiService.showConfirmDialog({
+          title: 'Error white parsing JSON',
+          text: 'The JSON body could not be parsed.',
+          subIcon: 'warning',
+          subIconClass: 'text-warning'
+        });
       }
     }
   }


### PR DESCRIPTION
**Technical implementation details**

Currently there is no json validation when beautifying json responses - only a comment that beatification should not occur in the catch


Closes #1365
