### PR TITLE
Fix null pointer when calling a firebase function without a body

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -385,8 +385,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     const requestContentType: string | undefined =
       request.header('Content-Type');
 
-    // body was already parsed (e.g. by firebase), 'data' event will not be emitted
-    if (!!request.body) {
+    // body was already parsed (e.g. by firebase), 'data' event will not be emitted (⚠️ request.body will always be an empty object in Firebase Functions, we have to check rawBody too)
+    if (!!request.body && request.rawBody) {
       this.processRawBody(request, next, [request.rawBody], requestContentType);
     } else {
       const rawBody: Buffer[] = [];


### PR DESCRIPTION
Firebase functions always populate the body with an empty object, even if there is no body, and no Content-Type header. rawBody presence needs to be checked too.

Closes #1413

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
