### PR TITLE
Add JS templating in responses. Closes 1435, 445.

### DIFF
--- a/packages/commons-server/src/libs/template-parser.ts
+++ b/packages/commons-server/src/libs/template-parser.ts
@@ -1,6 +1,11 @@
 import { Environment, ProcessedDatabucket } from '@mockoon/commons';
 import { Request, Response } from 'express';
-import { compile as hbsCompile } from 'handlebars';
+import {
+  SafeString,
+  compile as hbsCompile,
+  create as hbsCreate
+} from 'handlebars';
+import vm from 'node:vm';
 import { DataHelpers } from './templating-helpers/data-helpers';
 import { FakerWrapper } from './templating-helpers/faker-wrapper';
 import { GlobalHelpers } from './templating-helpers/global-helpers';
@@ -64,14 +69,107 @@ export const TemplateParser = function ({
     };
   }
 
-  try {
-    return hbsCompile(content)(
-      {},
-      {
-        helpers
+  enum TemplatingLanguage {
+    Handlebars = 'handlebars',
+    Javascript = 'javascript'
+  }
+
+  type TemplatingLanguageTest = {
+    regex?: RegExp;
+    language: TemplatingLanguage;
+  };
+
+  // test content against a sequence of regexes to infer templating language
+  const templatingLanguageSpecifiers: TemplatingLanguageTest[] = [
+    {
+      regex: /^\/\/\s*(javascript|js)/i,
+      language: TemplatingLanguage.Javascript
+    },
+    { language: TemplatingLanguage.Handlebars }
+  ];
+
+  const contentTemplatingLanguage = templatingLanguageSpecifiers.reduce(
+    (acc, curr) => {
+      if (!acc && (!curr.regex || curr.regex.test(content))) {
+        acc = curr.language;
       }
-    );
-  } catch (error) {
-    throw error;
+
+      return acc;
+    },
+    null as TemplatingLanguage | null
+  );
+
+  switch (contentTemplatingLanguage) {
+    case TemplatingLanguage.Javascript:
+      // Wrap the handlebars helper functions with an interface for calling directly from JS.
+      // Ordered handlebars parameters become ordered function arguments. Named handlebars
+      // parameters become a key/value object passed as the last js argument.
+      const directlyCallableHelpers = Object.fromEntries(
+        Object.entries(helpers).map(([helperName, helperFn]) => [
+          helperName,
+          function (this: any, ...args: any[]) {
+            // If the last argument is an object, assume it contains named parameters
+            // for the handlebars helper
+            if (typeof args[args.length - 1] === 'object') {
+              args.splice(args.length - 1, 1, {
+                hash: args[args.length - 1]
+              });
+            } else {
+              // If the last argument is not an object, add a placeholder options
+              // object, because helpers assume options is always provided
+              args = args.concat({});
+            }
+
+            return helperFn.apply(this, args);
+          }
+        ])
+      );
+
+      const sandbox = {
+        mockoon: directlyCallableHelpers,
+        helpers: { ...helpers }, // shallow copy so script cannot modify
+        handlebars: hbsCreate(), // siloed instance so script cannot damage
+        result: undefined, // script should populate with return value
+        console // allow script to console.log
+      };
+
+      const context = vm.createContext(sandbox);
+      const script = new vm.Script(content);
+
+      try {
+        script.runInContext(context);
+        if (
+          context.result instanceof SafeString ||
+          typeof context.result === 'string'
+        ) {
+          return context.result.toString();
+        } else {
+          return JSON.stringify(
+            context.result,
+            (key, val) => {
+              // unwrap any Handlebars.SafeString values
+              if (val instanceof SafeString) {
+                return val.toString();
+              }
+
+              return val;
+            },
+            2
+          );
+        }
+      } catch (error) {
+        throw error;
+      }
+    default:
+      try {
+        return hbsCompile(content)(
+          {},
+          {
+            helpers
+          }
+        );
+      } catch (error) {
+        throw error;
+      }
   }
 };

--- a/packages/commons-server/test/suites/js-response.spec.ts
+++ b/packages/commons-server/test/suites/js-response.spec.ts
@@ -1,0 +1,218 @@
+import { strictEqual } from 'assert';
+import { TemplateParser } from '../../src/libs/template-parser';
+
+describe('JS template parser', () => {
+  it('should interpret as JS when magic comment is present', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `// javascript
+      result = Array.from(Array(10).keys());`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(
+      parseResult,
+      JSON.stringify(Array.from(Array(10).keys()), null, 2)
+    );
+  });
+
+  it('should interpret as Handlebars when magic comment is absent', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: 'result = "hello " + "{{queryParam \'str\'}}";',
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {
+        query: {
+          str: 'world'
+        }
+      } as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'result = "hello " + "world";');
+  });
+
+  it('should directly invoke Mockoon helper functions', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = mockoon.queryParam('str');`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {
+        query: {
+          str: 'this is a test'
+        }
+      } as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'this is a test');
+  });
+
+  it('should directly invoke Mockoon helper functions with named parameters', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = mockoon.dateTimeShift({
+        date: '2021-02-01T10:45:00',
+        format: "yyyy-MM-dd'T'HH:mm:ss",
+        days: 8,
+        months: 3,
+        hours: 1,
+        minutes: 2,
+        seconds: 3
+      });`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, '2021-05-09T11:47:03');
+  });
+
+  it('should stringify object responses', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = {hello: "world", nums: [1, 2, 3]};`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(
+      parseResult,
+      JSON.stringify({ hello: 'world', nums: [1, 2, 3] }, null, 2)
+    );
+  });
+
+  it('should not modify string responses', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = "this is a test";`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'this is a test');
+  });
+
+  it('should unwrap Handlebars SafeStrings', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = mockoon.queryParam('str');`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {
+        query: {
+          str: 'this is a test'
+        }
+      } as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'this is a test');
+  });
+
+  it('should unwrap Handlebars SafeStrings inside of objects', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      result = {some: {nested: {obj: mockoon.queryParam('str')}}};`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {
+        query: {
+          str: 'this is a test'
+        }
+      } as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(
+      parseResult,
+      JSON.stringify({ some: { nested: { obj: 'this is a test' } } }, null, 2)
+    );
+  });
+
+  it('should return nothing if result is not set', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      // Not setting the 'result' variable`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, undefined);
+  });
+
+  it('should use Handlebars', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      const templateStr = 'Hello {{foo}}';
+      const template = handlebars.compile(templateStr);
+      result = template({foo: 'world'});`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'Hello world');
+  });
+
+  it('should use Mockoon helpers in Handlebars', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      const templateStr = '{{queryParam "str"}}';
+      const template = handlebars.compile(templateStr);
+      result = template({}, { helpers });`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {
+        query: {
+          str: 'this is a test'
+        }
+      } as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'this is a test');
+  });
+
+  it('should use custom helpers in Handlebars', () => {
+    const parseResult = TemplateParser({
+      shouldOmitDataHelper: false,
+      content: `//JS
+      const templateStr = '{{camelcase "this is a test"}}';
+      const template = handlebars.compile(templateStr);
+      helpers.camelcase = (str) => str.toString().toLowerCase().replace(
+        /[^a-zA-Z0-9]+(.)/g,
+        (m, chr) => chr.toUpperCase()
+      );
+      result = template({}, { helpers });`,
+      environment: {} as any,
+      processedDatabuckets: [],
+      globalVariables: {},
+      request: {} as any,
+      envVarsPrefix: ''
+    });
+    strictEqual(parseResult, 'thisIsATest');
+  });
+});


### PR DESCRIPTION
**Technical implementation details**

- Detects user intent to utilize Javascript with a magic comment in the response: `//JS` or `// javascript`.
- Uses a `node:vm` with an isolated sandbox to execute the Javascript
- Injects Mockoon's built-in handlebars helpers, each wrapped with an interface to allow calling as a Javascript function from within the script. Ordered and named parameters are bridged, and SafeStrings are unwrapped in the return value. This collection of helpers is exposed as `mockoon` in the global scope within the script. This should be self maintaining: as new helpers are added they will be automatically available to both Handlebars and Javascript.
- A siloed Handlebars instance is also exposed to the script in the `handlebars` global variable. Mockoon's unmodified Handlebars helpers are exposed as `helpers`. Users can use Javascript to compile template strings and pass in Mockoon's built-in helpers, along with custom helpers defined in the script. This addresses #445 .
- A global variable `result` is available to the script. The user must assign the final value for the response to this variable, from which the template parser consumes it.
- Results of type `string` are used as-is. Object types are stringified, allowing for powerful generation of JSON responses.

Example of invoking Javascript in a response:
```javascript
// javascript
result = Array.from(Array(10).keys());
```

Example of invoking Mockoon functionality in Javascript:
```javascript
// javascript
result = mockoon.queryParam('str');
```

Example of invoking Mockoon functionality with named parameters in Javascript:
```javascript
// javascript
result = mockoon.dateTimeShift({
  date: "2021-01-01",
  format: "yyyy-MM-dd HH:mm:ss",
  years: 1,
  months: 1,
  days: 1,
  hours: 1,
  minutes: 1,
  seconds: 1,
});
```

Example of using Javascript to invoke Handlebars:
```javascript
// javascript
const templateStr = '{{queryParam "this is a test"}}';
const template = handlebars.compile(templateStr);
result = template({}, { helpers });
```

Example of using Javascript to invoke Handlebars while adding a custom helper:
```javascript
// javascript
helpers.camelcase = (str) => str.toString().toLowerCase().replace(
  /[^a-zA-Z0-9]+(.)/g,
  (m, chr) => chr.toUpperCase()
);
const templateStr = '{{camelcase (queryParam "this is a test")}}';
const template = handlebars.compile(templateStr);
result = template({}, { helpers });
```


**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)


Closes #1435 
Closes #445 