### PR TITLE
Support named path parameters for websocket routes #1495

### DIFF
--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
         "@faker-js/faker": "8.4.1",
-        "@mockoon/commons": "8.4.0",
         "append-field": "1.0.0",
         "busboy": "1.6.0",
         "cookie-parser": "1.4.6",
@@ -23,6 +22,7 @@
         "killable": "1.0.1",
         "mime-types": "2.1.35",
         "object-path": "0.11.8",
+        "path-to-regexp": "7.1.0",
         "qs": "6.12.3",
         "range-parser": "1.2.1",
         "typed-emitter": "2.1.0",
@@ -261,19 +261,6 @@
         "npm": ">=6.14.13"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -336,17 +323,6 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "node_modules/@mockoon/commons": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@mockoon/commons/-/commons-8.4.0.tgz",
-      "integrity": "sha512-4rJE2l+NqmZWezcXXTOGH76v/y+qzKJbji0v+MxJPZWvaPlH/iNpUSTzky/9qerldS1SVgqhe5tCfbMfVwR8Hg==",
-      "dependencies": {
-        "joi": "17.13.3"
-      },
-      "funding": {
-        "url": "https://mockoon.com/sponsor-us/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -393,24 +369,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -1917,6 +1875,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
     "node_modules/express/node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -2707,18 +2670,6 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
-    "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -3307,9 +3258,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.1.0.tgz",
+      "integrity": "sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -1876,9 +1876,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
     },
     "node_modules/express/node_modules/qs": {
       "version": "6.13.0",

--- a/packages/commons-server/package.json
+++ b/packages/commons-server/package.json
@@ -46,6 +46,7 @@
     "killable": "1.0.1",
     "mime-types": "2.1.35",
     "object-path": "0.11.8",
+    "path-to-regexp": "7.1.0",
     "qs": "6.12.3",
     "range-parser": "1.2.1",
     "typed-emitter": "2.1.0",

--- a/packages/commons-server/src/libs/requests.ts
+++ b/packages/commons-server/src/libs/requests.ts
@@ -2,7 +2,7 @@ import { Request } from 'express';
 import { IncomingMessage } from 'http';
 import { match } from 'path-to-regexp';
 
-import { Route } from '@mockoon/commons';
+import { CloneObject, Route } from '@mockoon/commons';
 import { parse as parseUrl } from 'url';
 import { parseRequestMessage, parseWebSocketMessage } from './utils';
 
@@ -125,8 +125,8 @@ export const fromWsRequest = (
       req.socket?.remoteAddress,
     method: req.method,
     originalRequest: req,
-    params: JSON.parse(JSON.stringify(pathParams)),
-    query: JSON.parse(JSON.stringify(location.query)),
+    params: CloneObject(pathParams),
+    query: CloneObject(location.query),
     stringBody: message || toString(req.body) || ''
   } as ServerRequest;
 };

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -7,7 +7,6 @@ import {
   Environment,
   FileExtensionsWithTemplating,
   GetContentType,
-  getLatency,
   GetRouteResponseContentType,
   Header,
   IsValidURL,
@@ -26,6 +25,7 @@ import {
   defaultEnvironmentVariablesPrefix,
   defaultMaxTransactionLogs,
   generateUUID,
+  getLatency,
   stringIncludesArrayItems
 } from '@mockoon/commons';
 import appendField from 'append-field';
@@ -48,6 +48,7 @@ import {
 import killable from 'killable';
 import { lookup as mimeTypeLookup } from 'mime-types';
 import { basename, extname } from 'path';
+import { match } from 'path-to-regexp';
 import { parse as qsParse } from 'qs';
 import rangeParser from 'range-parser';
 import { SecureContextOptions } from 'tls';
@@ -581,7 +582,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     wsRoutes.forEach((wsRoute) => {
       const webSocketServer = new WebSocket.Server({
         noServer: true,
-        path: `${envPath}/${wsRoute.endpoint}`
+        path: `${envPath}`
       });
 
       this.webSocketServers.push(webSocketServer);
@@ -591,10 +592,15 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         this.createWebSocketConnectionHandler(webSocketServer, wsRoute)
       );
 
+      const pathMatcherFn = match(
+        wsRoute.endpoint.startsWith('/')
+          ? wsRoute.endpoint
+          : '/' + wsRoute.endpoint
+      );
+
       this.serverInstance.on('upgrade', (req, socket, head) => {
-        //
         const urlParsed = parseUrl(req.url || '', true);
-        if (urlParsed.pathname === `${envPath}/${wsRoute.endpoint}`) {
+        if (pathMatcherFn(urlParsed.pathname || '')) {
           webSocketServer.handleUpgrade(req, socket, head, (client) => {
             webSocketServer.emit('connection', client, req);
           });
@@ -666,7 +672,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         );
       });
 
-      const serverRequest = fromWsRequest(request);
+      const serverRequest = fromWsRequest(request, route);
 
       // This is not waiting until a messge from client. But will push messages as a stream.
       if (route.streamingMode === StreamingMode.BROADCAST) {
@@ -788,7 +794,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     let content: any = enabledRouteResponse.body;
     let finalRequest = connectedRequest;
     if (!finalRequest) {
-      finalRequest = request ? fromWsRequest(request, data) : undefined;
+      finalRequest = request ? fromWsRequest(request, route, data) : undefined;
     }
 
     if (
@@ -937,7 +943,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     const intervalRef = setInterval(() => {
       const enabledRouteResponse = new ResponseRulesInterpreter(
         route.responses,
-        fromWsRequest(request),
+        fromWsRequest(request, route),
         route.responseMode,
         this.environment,
         this.processedDatabuckets,
@@ -2146,7 +2152,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       new RegExp('data(?:Raw)? +[\'|"]{1}([^(\'|")]*)', 'g')
     );
 
-    return [...(matches || [])].map((match) => match[1]);
+    return [...(matches || [])].map((mtc) => mtc[1]);
   }
 
   /**

--- a/packages/commons-server/test/suites/server/ws.spec.ts
+++ b/packages/commons-server/test/suites/server/ws.spec.ts
@@ -31,7 +31,12 @@ const EMPTY_SERVER_CTX = {
   envVarPrefix: ''
 } as ServerContext;
 
-const EMPTY_WS_REQUEST = fromWsRequest({} as IncomingMessage);
+const EMPTY_WS_REQUEST = fromWsRequest(
+  {} as IncomingMessage,
+  {
+    endpoint: 'api/path1/test'
+  } as Route
+);
 
 describe('Minimum Streaming Interval', () => {
   it('minimum interval should not lower than 10ms', () => {

--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
@@ -405,7 +405,7 @@
                     *ngIf="
                       rulesDisablingResponseModes.includes(
                         data.activeRoute?.responseMode
-                      ) || !!data.activeRoute.streamingMode
+                      ) || data.activeRoute.streamingMode === 'BROADCAST'
                     "
                     class="text-warning"
                     [ngbTooltip]="texts.DISABLED_RULES_WARNING"

--- a/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.html
+++ b/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.html
@@ -43,11 +43,7 @@
               class="overflow-hidden me-2"
               formControlName="target"
               [enableCustomInput]="false"
-              [items]="
-                activeRoute.type === 'ws'
-                  ? webSocketResponseRuleTargets
-                  : responseRuleTargets
-              "
+              [items]="responseRuleTargets"
               [dropdownId]="'rules' + ruleIndex + 'target'"
             ></app-custom-select>
 

--- a/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.html
+++ b/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.html
@@ -44,11 +44,7 @@
               formControlName="target"
               [enableCustomInput]="false"
               [hasCategory]="true"
-              [items]="
-                activeRoute.type === 'ws'
-                  ? webSocketResponseRuleTargets
-                  : responseRuleTargets
-              "
+              [items]="responseRuleTargets"
               [dropdownId]="'rules' + ruleIndex + 'target'"
             ></app-custom-select>
 

--- a/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
+++ b/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
@@ -60,9 +60,6 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     { value: 'data_bucket', label: 'Data bucket' },
     { value: 'request_number', label: 'Request number (starting at 1)' }
   ];
-  public webSocketResponseRuleTargets = this.responseRuleTargets.filter(
-    (rt) => !['cookie', 'params'].includes(rt.value)
-  );
   public responseRuleOperators: DropdownItems<ResponseRuleOperators> = [
     { value: 'equals', label: 'equals' },
     { value: 'regex', label: 'regex' },

--- a/packages/desktop/src/renderer/app/constants/texts.constant.ts
+++ b/packages/desktop/src/renderer/app/constants/texts.constant.ts
@@ -1,6 +1,6 @@
 export const Texts = {
   DISABLED_RULES_WARNING:
-    'Rules disabled by one of the response modes (sequential, random, rules disabled) or when in streaming mode',
+    'Rules disabled by one of the response modes (sequential, random, rules disabled) or when in broadcast streaming mode',
   MINIMUM_STREAMING_INTERVAL_WARNING:
     'Minimum streaming interval should be 10ms'
 };


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

Initial WebSocket release (#83) has a limitation on not supporting named path variables. This is because, the used library does not implement it. But this PR implements the support on path variables using the same library, called [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) used by [express.js](https://github.com/expressjs/express/blob/master/package.json#L50) itself.
In turn, now `Route parameter` option can be selected when defining a rule.

Note: Since broadcasting events are independent of client input, these path parameters does not make applicable. Anyway, the rules are already disabled in broadcasting endpoints.

**Checklist**

<!-- Check relevant boxes -->

- [ ] (Not Applicable) data migration added (@mockoon/commons) 
- [x] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] (Not Applicable) CLI tests added (@mockoon/cli)
- [x] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #1495 
