### PR TITLE
Fix rules inputs not staying disabled after navigation

### DIFF
--- a/packages/desktop/src/renderer/app/app.module.ts
+++ b/packages/desktop/src/renderer/app/app.module.ts
@@ -164,7 +164,10 @@ import { AppComponent } from './app.component';
 
       return functions;
     }),
-    ReactiveFormsModule,
+    ReactiveFormsModule.withConfig({
+      // enable the legacy disabled state handling (angular v15)
+      callSetDisabledState: 'whenDisabledForLegacyCode'
+    }),
     NgxMaskDirective
   ],
   providers: [


### PR DESCRIPTION
This is apparently due to a change in Angular 15. We should use FormControl.disable() but let's stick with [attr.disabled] for now Closes #1517

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
