### PR TITLE
Fix bug where updateById CRUD operation was not keeping custom Ids

### DIFF
--- a/packages/commons-server/src/libs/server/crud.ts
+++ b/packages/commons-server/src/libs/server/crud.ts
@@ -274,12 +274,29 @@ export const databucketActions = (
             typeof databucket.value[indexToModify] === 'object' &&
             databucket.value[indexToModify] != null
           ) {
+            const currentItemId = getPath(
+              databucket.value[indexToModify],
+              convertPathToArray(routeCrudKey)
+            );
+
             databucket.value[indexToModify] = {
-              id: databucket.value[indexToModify].id,
               ...(typeof requestBody === 'object' && requestBody != null
                 ? requestBody
                 : {})
             };
+
+            // restore the id if it was not provided in the request body
+            if (
+              getPath(requestBody, convertPathToArray(routeCrudKey)) ===
+              undefined
+            ) {
+              setPath(
+                databucket.value[indexToModify],
+                convertPathToArray(routeCrudKey),
+                currentItemId
+              );
+            }
+
             responseBody = databucket.value[indexToModify];
           } else {
             databucket.value[indexToModify] = requestBody;

--- a/packages/desktop/test/specs/crud.spec.ts
+++ b/packages/desktop/test/specs/crud.spec.ts
@@ -299,7 +299,7 @@ const jsonArrayTestGroups: HttpCall[][] = [
       body: { test: 'hello' },
       testedResponse: {
         status: 200,
-        body: '{"id":"abcd","test":"hello"}',
+        body: '{"test":"hello","id":"abcd"}',
         headers: { 'content-type': 'application/json' }
       }
     },
@@ -310,7 +310,7 @@ const jsonArrayTestGroups: HttpCall[][] = [
       headers: { 'content-type': 'application/json' },
       testedResponse: {
         status: 200,
-        body: '[{"id":"abcd","test":"hello"}]',
+        body: '[{"test":"hello","id":"abcd"}]',
         headers: {
           'content-type': 'application/json',
           'x-total-count': '1',


### PR DESCRIPTION
Closes #1548

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
