### PR TITLE
Fix CRUD responses tab switching

### DIFF
--- a/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
+++ b/packages/desktop/src/renderer/app/components/environment-routes/environment-routes.component.html
@@ -528,12 +528,16 @@
               <!-- http: status code + latency, crud: databucket id + latency (if default response), otherwise same as http -->
               <div class="mt-3 mx-2">
                 <div
-                  ngClass="route-responses-{{
-                    data.activeRoute?.type === 'crud' &&
-                    data.activeRouteResponse?.default
-                      ? 'crud'
-                      : data.activeRoute.type
-                  }}"
+                  [ngClass]="{
+                    'route-responses-http':
+                      data.activeRoute?.type === 'http' ||
+                      (data.activeRoute?.type === 'crud' &&
+                        !data.activeRouteResponse?.default),
+                    'route-responses-crud':
+                      data.activeRoute?.type === 'crud' &&
+                      data.activeRouteResponse?.default,
+                    'route-responses-ws': data.activeRoute?.type === 'ws'
+                  }"
                 >
                   <app-custom-select
                     *ngIf="

--- a/packages/desktop/src/renderer/app/stores/reducer-utils.ts
+++ b/packages/desktop/src/renderer/app/stores/reducer-utils.ts
@@ -324,3 +324,39 @@ export const findRouteFolderHierarchy = (
 
   return [];
 };
+
+/**
+ * Check that we are not switching from a regular response to a CRUD
+ * operation response where some tabs are not available.
+ * If so, switch to the RESPONSE tab.
+ *
+ * @param state
+ * @param routeResponseUuid
+ * @returns
+ */
+export const responseTabForcedNavigation = (
+  state: StoreType,
+  routeResponseUuid: string
+) => {
+  let newActiveTab = state.activeTab;
+
+  const activeEnvironment = state.environments.find(
+    (environment) => environment.uuid === state.activeEnvironmentUUID
+  );
+  const activeRoute = activeEnvironment.routes.find(
+    (route) => route.uuid === state.activeRouteUUID
+  );
+  const activatedRouteResponse = activeRoute.responses.find(
+    (response) => response.uuid === routeResponseUuid
+  );
+
+  if (
+    activeRoute.type === 'crud' &&
+    activatedRouteResponse.default &&
+    !['RESPONSE', 'HEADERS'].includes(state.activeTab)
+  ) {
+    newActiveTab = 'RESPONSE';
+  }
+
+  return newActiveTab;
+};

--- a/packages/desktop/src/renderer/app/stores/reducer.ts
+++ b/packages/desktop/src/renderer/app/stores/reducer.ts
@@ -38,6 +38,7 @@ import {
   getBodyEditorMode,
   getFirstRouteAndResponseUUIDs,
   markEnvStatusRestart,
+  responseTabForcedNavigation,
   updateDuplicatedRoutes,
   updateEditorAutocomplete
 } from 'src/renderer/app/stores/reducer-utils';
@@ -848,7 +849,7 @@ export const environmentReducer = (
         return environment;
       });
 
-      // always focus the first route response if the active one  is removed (even with cloud sync)
+      // always focus the first route response if the active one is removed (even with cloud sync)
       const newRouteResponses = newEnvironment.routes.find(
         (route) => route.uuid === action.routeUuid
       ).responses;
@@ -857,7 +858,11 @@ export const environmentReducer = (
         ...state,
         activeRouteResponseUUID:
           newRouteResponses.length > 0 ? newRouteResponses[0].uuid : null,
-        environments: newEnvironments
+        environments: newEnvironments,
+        activeTab:
+          newRouteResponses.length > 0
+            ? responseTabForcedNavigation(state, newRouteResponses[0].uuid)
+            : 'RESPONSE'
       };
       break;
     }
@@ -1176,7 +1181,11 @@ export const environmentReducer = (
       if (action.routeResponseUUID !== state.activeRouteResponseUUID) {
         newState = {
           ...state,
-          activeRouteResponseUUID: action.routeResponseUUID
+          activeRouteResponseUUID: action.routeResponseUUID,
+          activeTab: responseTabForcedNavigation(
+            state,
+            action.routeResponseUUID
+          )
         };
         break;
       }


### PR DESCRIPTION
If use navigates to a tab not available in the CRUD default response (the CRUD operations response) on a secondary response, like "callbacks" or "Settings", and switch back to the default response, the tab stays focused even if it doesn't exists. Also fix CSS grid classes not being correctly selected depending on the route type. Closes #1552

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
