### PR TITLE
chore: update jsonpath-plus package

### DIFF
--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
         "@faker-js/faker": "8.4.1",
+        "@mockoon/commons": "8.4.0",
+        "ajv": "8.17.1",
         "append-field": "1.0.0",
         "busboy": "1.6.0",
         "cookie-parser": "1.4.6",
@@ -18,7 +20,7 @@
         "express": "4.21.0",
         "handlebars": "4.7.8",
         "http-proxy-middleware": "2.0.6",
-        "jsonpath-plus": "8.1.0",
+        "jsonpath-plus": "10.0.0",
         "killable": "1.0.1",
         "mime-types": "2.1.35",
         "object-path": "0.11.8",
@@ -261,6 +263,21 @@
         "npm": ">=6.14.13"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha1-g2iGnctzW+Ln9ct2R9544WeiUfs=",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha1-3ESOMyxsbjek3AL9hLqNRLmvsBI=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -323,6 +340,42 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha1-Byd73XhiRRqGXTkeIULvujP0bJs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha1-Ouqi5fpF2J3hFq6vv6QclZNbf20=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@mockoon/commons": {
+      "version": "8.4.0",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@mockoon/commons/-/commons-8.4.0.tgz",
+      "integrity": "sha1-4OFoovzdFr1Bys0yKFSEdmK04IU=",
+      "license": "MIT",
+      "dependencies": {
+        "joi": "17.13.3"
+      },
+      "funding": {
+        "url": "https://mockoon.com/sponsor-us/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -369,6 +422,27 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha1-S8FJoAdmI87ZnKggi6eA1lqZudU=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha1-gPy8uvfOAx4O8t0psb/Hw/WDYR8=",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha1-z/j/rcNyrSn9P3gneusp5jLMcN8=",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2670,6 +2744,19 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha1-D1zBFpyZmzDTRDZtOEsS2SVYvOw=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -2695,6 +2782,15 @@
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.3.9",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/jsep/-/jsep-1.3.9.tgz",
+      "integrity": "sha1-jOQt+A7pwbOeUtDdBipGU0LzVEA=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/json-buffer": {
@@ -2740,15 +2836,21 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-8.1.0.tgz",
-      "integrity": "sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==",
+      "version": "10.0.0",
+      "resolved": "https://pkgs.dev.azure.com/diemobiliar/RWC/_packaging/npm-main/npm/registry/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz",
+      "integrity": "sha1-enR9R+IKJ4Z9u8gLV/1VR4i5FHQ=",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",
         "jsonpath-plus": "bin/jsonpath-cli.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsprim": {

--- a/packages/commons-server/package.json
+++ b/packages/commons-server/package.json
@@ -43,7 +43,7 @@
     "express": "4.21.0",
     "handlebars": "4.7.8",
     "http-proxy-middleware": "2.0.6",
-    "jsonpath-plus": "8.1.0",
+    "jsonpath-plus": "10.0.0",
     "killable": "1.0.1",
     "mime-types": "2.1.35",
     "object-path": "0.11.8",


### PR DESCRIPTION
**Technical implementation details**
jsonpath-plus@8.4.0 has a critical vulnerability. This updates this package to a non-vulnerable version

Closes

https://github.com/mockoon/mockoon/security/advisories/GHSA-w3mj-ccgc-h8m9
