### PR TITLE
#611 Issue: secure flag not removing from set cookie fix

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1771,9 +1771,9 @@ server.use(
         this.environment.proxyRemovePrefix === true &&
         this.environment.endpointPrefix.length > 0
       ) {
-        // Implement your logic for path rewriting here
+        
       }
-      return path; // Ensure to return the modified path or the original
+      return path; 
     },
     ssl: { ...this.tlsOptions, agent: false },
     onProxyReq: (proxyReq, request, response) => {
@@ -1877,7 +1877,7 @@ server.use(
     error: any,
     request: Request,
     response: Response,
-    _next: NextFunction
+    _next: NextFunction,
   ) => {
     this.sendError(response, error, 500);
   };

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1877,10 +1877,11 @@ server.use(
     error: any,
     request: Request,
     response: Response,
-    _next: NextFunction,
-  ) => {
+    _next: NextFunction
+) => {
     this.sendError(response, error, 500);
-  };
+};
+
 
   /**
    * Set the provided headers on the target. Use different headers accessors

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1756,9 +1756,9 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       IsValidURL(this.environment.proxyHost)
     ) {
       this.emit('creating-proxy');
+this.emit('creating-proxy');
 
-      server.use(
-
+server.use(
   '*',
   createProxyMiddleware({
     cookieDomainRewrite: { '*': '' },
@@ -1770,23 +1770,21 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       if (
         this.environment.proxyRemovePrefix === true &&
         this.environment.endpointPrefix.length > 0
-      ) 
+      ) {
+        // Implement your logic for path rewriting here
+      }
+      return path; // Ensure to return the modified path or the original
+    },
+    ssl: { ...this.tlsOptions, agent: false },
+    onProxyReq: (proxyReq, request, response) => {
+      this.refreshEnvironment();
+      request.proxied = true;
+      this.setHeaders(this.environment.proxyReqHeaders, proxyReq, request);
 
-  ssl: { ...this.tlsOptions, agent: false },
-  onProxyReq: (proxyReq, request, response) => {
-    this.refreshEnvironment();
-    request.proxied = true;
-
-    this.setHeaders(
-      this.environment.proxyReqHeaders,
-      proxyReq,
-      request
-    );
-  }
-
-
-        
-
+      // Re-stream the body (intercepted by body parser method)
+      if (request.rawBody) {
+        proxyReq.write(request.rawBody);
+      }
     },
     onProxyRes: (proxyRes, req, res) => {
       // Modify 'Set-Cookie' headers to remove 'Secure' flag
@@ -1800,13 +1798,6 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
   })
 );
 
-         
-            // re-stream the body (intercepted by body parser method)
-            if (request.rawBody) {
-              proxyReq.write(request.rawBody);
-            }
-          
-          onProxyRes: (proxyRes, request, response) => {
             this.refreshEnvironment();
 
         createProxyMiddleware({

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1853,35 +1853,14 @@ server.use(
                 request as Request
               );
             },
-            error: (error, request, response) => {
-              this.emit('error', ServerErrorCodes.PROXY_ERROR, error);
-
-              this.sendError(
-                response as Response,
-                `${format(
-                  ServerMessages.PROXY_ERROR,
-                  this.environment.proxyHost
-                )} ${request.url}: ${error}`,
-                504
-              );
-            }
-          }
-  /**
+   /**         
    * ### Middleware ###
    * Catch all error handler
    * http://expressjs.com/en/guide/error-handling.html#catching-errors
    *
    * @param server - server on which to log the response
    */
-  private errorHandler = (
-    error: any,
-    request: Request,
-    response: Response,
-    _next: NextFunction
-) => {
-    this.sendError(response, error, 500);
-};
-
+  
 
   /**
    * Set the provided headers on the target. Use different headers accessors


### PR DESCRIPTION
## Fix: Remove `Secure` Flag from `Set-Cookie` Headers When Proxying over HTTP

### Issue Overview
When Mockoon proxies requests to an HTTPS service that sets cookies with the `Secure` flag, the `Secure` flag was not removed when the response was proxied over HTTP. This behavior could lead to insecure environments being unable to store or manage cookies correctly.

### Changes Made

1. **Modified `setHeaders` Function:**
   - The `setHeaders` function now checks for `Set-Cookie` headers. If a `Set-Cookie` header is found and contains the `Secure` flag, it is stripped out when the request is proxied over HTTP.
   - Added logic to safely remove the `Secure` flag using:
     ```ts
     if (isSetCookie) {
       parsedHeaderValue = parsedHeaderValue.replace(/;\s*Secure/i, '');
     }
     ```

2. **Updated Proxy Middleware (`createProxyMiddleware`):**
   - Integrated an `onProxyRes` handler to intercept the response from the proxied HTTPS service. The handler inspects the `Set-Cookie` headers and removes the `Secure` flag if present.
   - Added the following to the proxy configuration:
     ```ts
     onProxyRes: (proxyRes, req, res) => {
       const setCookieHeaders = proxyRes.headers['set-cookie'];
       if (setCookieHeaders) {
         proxyRes.headers['set-cookie'] = setCookieHeaders.map((cookie) =>
           cookie.replace(/;\s*Secure/i, '')
         );
       }
     }
     ```

### Impact
With these changes, Mockoon will now properly handle secure cookies when proxying requests over HTTP by removing the `Secure` flag from the `Set-Cookie` headers. This ensures that cookies are stored and managed correctly in environments where HTTPS is not used on the client-side.
