### PR TITLE
Add option to disable admin API during cloud deployment

### DIFF
--- a/packages/cloud/src/models/deploy-instance.model.ts
+++ b/packages/cloud/src/models/deploy-instance.model.ts
@@ -15,4 +15,5 @@ export type DeployInstance = {
   status: DeployInstanceStatus;
   name: string;
   apiKey: string | null;
+  enableAdminApi: boolean;
 };

--- a/packages/desktop/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.html
+++ b/packages/desktop/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.html
@@ -18,19 +18,43 @@
 
   <div class="modal-body">
     <div [formGroup]="optionsForm">
-      <div class="d-flex align-items-center">
-        <div class="me-2">Instance visibility:</div>
-        <app-toggle
-          prefix="instance-visibility"
-          formControlName="visibility"
-          [items]="visibilityToggle"
-          [uncheckable]="false"
-        ></app-toggle>
-        <div class="ms-2">
-          <app-svg
-            icon="info"
-            ngbTooltip="Public instances are accessible by anyone with the URL. Private instances are only accessible by you and your team members using a token."
-          ></app-svg>
+      <div class="mb-3">
+        <div class="input-group align-items-center">
+          <label class="col-form-label pe-2">Instance visibility</label>
+          <app-toggle
+            prefix="instance-visibility"
+            formControlName="visibility"
+            [items]="visibilityToggle"
+            [uncheckable]="false"
+          ></app-toggle>
+          <div class="input-group-text">
+            <app-svg
+              icon="info"
+              ngbTooltip="Public instances are accessible by anyone with the URL. Private instances are only accessible by you and your team members using a token."
+            ></app-svg>
+          </div>
+        </div>
+      </div>
+
+      <div class="">
+        <div class="input-group align-items-center">
+          <div class="form-check">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              id="enableAdminApi"
+              formControlName="enableAdminApi"
+            />
+            <label class="form-check-label" for="enableAdminApi">
+              Enable admin API
+            </label>
+          </div>
+          <div class="input-group-text">
+            <app-svg
+              icon="info"
+              ngbTooltip="Enable the admin API expose on /mockoon-admin endpoint. This API allows you to manage your instances remotely."
+            ></app-svg>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/desktop/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.ts
+++ b/packages/desktop/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.ts
@@ -33,7 +33,8 @@ export class DeployInstanceModalComponent extends Logger implements OnInit {
     visibility: this.formBuilder.control<DeployInstanceVisibility>(
       DeployInstanceVisibility.PRIVATE,
       Validators.required
-    )
+    ),
+    enableAdminApi: this.formBuilder.control<boolean>(true)
   });
   public visibilityToggle: ToggleItems = [
     {
@@ -76,7 +77,8 @@ export class DeployInstanceModalComponent extends Logger implements OnInit {
 
         if (existingInstance) {
           this.optionsForm.patchValue({
-            visibility: existingInstance.visibility
+            visibility: existingInstance.visibility,
+            enableAdminApi: existingInstance.enableAdminApi
           });
         }
 


### PR DESCRIPTION
Closes #1572

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
