### PR TITLE
Introducing Mockoon Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://mockoon.com/newsletter/"><img src="https://img.shields.io/badge/Newsletter-Subscribe-green.svg?style=flat-square"/></a>
   <a href="https://twitter.com/GetMockoon"><img src="https://img.shields.io/badge/Twitter_@GetMockoon-follow-blue.svg?style=flat-square&colorB=1da1f2"/></a>
   <a href="https://mockoon.com/discord/"><img src="https://img.shields.io/badge/Discord-go-blue.svg?style=flat-square&colorA=6c84d9&colorB=1da1f2"/></a>  
+  <a href="https://gurubase.io/g/mockoon"><img src="https://img.shields.io/badge/Gurubase-Ask%20Mockoon%20Guru-006BFF?style=flat-square"/></a>
   <br>
   <br>
   <h1>Mockoon: awesome API mocking</h1>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Mockoon Guru](https://gurubase.io/g/mockoon) to Gurubase. Mockoon Guru uses the data from this repo and data from the [docs](https://mockoon.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Mockoon Guru", which highlights that Mockoon now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Mockoon Guru in Gurubase, just let me know that's totally fine.
