### PR TITLE
All path rule comparison against original path with parameters

### DIFF
--- a/packages/commons-server/src/libs/response-rules-interpreter.ts
+++ b/packages/commons-server/src/libs/response-rules-interpreter.ts
@@ -270,7 +270,7 @@ export class ResponseRulesInterpreter {
    * Extract rules targets from the request (body, headers, etc)
    */
   private extractTargets() {
-    const requestContentType = this.request.header('Content-Type');
+    const requestContentType = this.request.header('Content-Type') as string;
     let body: ParsedQs | JSON | string = this.request.stringBody;
 
     if (
@@ -294,7 +294,7 @@ export class ResponseRulesInterpreter {
       global_var: this.globalVariables,
       data_bucket: dataBucketTargets,
       method: this.request.method?.toLowerCase(),
-      path: this.request.originalRequest.url
+      path: [this.request.originalRequest.url, this.request.originalPath]
     };
   }
 

--- a/packages/commons-server/src/libs/server/events-listeners.ts
+++ b/packages/commons-server/src/libs/server/events-listeners.ts
@@ -166,7 +166,7 @@ export const listenServerEvents = function (
           )
         : [];
     }
-    logger.info('WebSocket New Connection', logMeta);
+    logger.info('New WebSocket connection', logMeta);
   });
 
   server.on(
@@ -192,7 +192,7 @@ export const listenServerEvents = function (
             )
           : [];
       }
-      logger.info('WebSocket Message Recieved', logMeta);
+      logger.info('WebSocket message received', logMeta);
     }
   );
 
@@ -216,7 +216,7 @@ export const listenServerEvents = function (
           : [];
       }
 
-      logger.info('WebSocket Closed', logMeta);
+      logger.info('WebSocket closed', logMeta);
     }
   );
 };

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -35,11 +35,7 @@ import { EventEmitter } from 'events';
 import express, { Application, NextFunction, Request, Response } from 'express';
 import { createReadStream, readFile, readFileSync, statSync } from 'fs';
 import type { RequestListener } from 'http';
-import {
-  IncomingMessage,
-  createServer as httpCreateServer,
-  Server as httpServer
-} from 'http';
+import { createServer as httpCreateServer, Server as httpServer } from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import {
   createServer as httpsCreateServer,
@@ -671,7 +667,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     webSocketServer: WebSocketServer,
     routeFor: Route
   ) {
-    return (socket: WebSocket, request: IncomingMessage) => {
+    return (socket: WebSocket, request: Request) => {
       // Refresh the environment when a new client is connected.
       this.refreshEnvironment();
       const route = this.getRefreshedRoute(routeFor);
@@ -837,7 +833,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     socket: WebSocket,
     route: Route,
     enabledRouteResponse: RouteResponse,
-    request?: IncomingMessage,
+    request?: Request,
     data?: string,
     connectedRequest?: ServerRequest
   ): string | undefined {
@@ -983,7 +979,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
   private handleOneToOneStreamingResponses(
     socket: WebSocket,
     route: Route,
-    request: IncomingMessage,
+    request: Request,
     baseErrorMeta: any
   ) {
     let responseNumber = 1;

--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -585,7 +585,7 @@ export const parseRequestMessage = (
   data: string,
   request?: ServerRequest
 ): any => {
-  const contentType = request?.header('content-type');
+  const contentType = request?.header('content-type') as string;
 
   return parseByContentType(data, contentType);
 };

--- a/packages/commons-server/test/specs/requests.test.ts
+++ b/packages/commons-server/test/specs/requests.test.ts
@@ -1,7 +1,6 @@
 import { Route } from '@mockoon/commons';
 import { Request } from 'express';
 import { ParamsDictionary, Query } from 'express-serve-static-core';
-import { IncomingMessage } from 'http';
 import { deepStrictEqual, notStrictEqual, strictEqual } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
@@ -13,7 +12,7 @@ import {
 describe('Requests', () => {
   describe('fromExpressRequest', () => {
     it('should create ServerRequest correctly from empty express request', () => {
-      const req = {} as Request;
+      const req = { route: { path: '' } } as Request;
       const result = fromExpressRequest(req);
 
       strictEqual(result.body, undefined);
@@ -34,7 +33,8 @@ describe('Requests', () => {
     it('should return body and stringBody correctly', () => {
       const req = {
         body: { a: 1, text: 'hello' },
-        stringBody: "{ a: 1, text: 'hello' }"
+        stringBody: "{ a: 1, text: 'hello' }",
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       deepStrictEqual(result.body, { a: 1, text: 'hello' });
@@ -43,7 +43,8 @@ describe('Requests', () => {
 
     it('should return cookies correctly', () => {
       const req = {
-        cookies: { 'session-id': 'abc' } as any
+        cookies: { 'session-id': 'abc' } as any,
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       deepStrictEqual(result.cookies, { 'session-id': 'abc' });
@@ -55,7 +56,8 @@ describe('Requests', () => {
         accept: 'text/html'
       };
       const req = {
-        header: (name: string) => headers[name]
+        header: (name: string) => headers[name],
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       strictEqual(result.header('content-type'), 'application/json');
@@ -68,7 +70,8 @@ describe('Requests', () => {
         params: {
           path1: 'value1',
           path2: 'value2'
-        } as ParamsDictionary
+        } as ParamsDictionary,
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       deepStrictEqual(result.params, {
@@ -82,7 +85,8 @@ describe('Requests', () => {
         query: {
           search: 'abc',
           range: '1'
-        } as Query
+        } as Query,
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       deepStrictEqual(result.query, {
@@ -95,7 +99,8 @@ describe('Requests', () => {
       const req = {
         hostname: 'localhost',
         ip: '127.0.0.2',
-        method: 'GET'
+        method: 'GET',
+        route: { path: '' }
       } as Request;
       const result = fromExpressRequest(req);
       strictEqual(result.hostname, 'localhost');
@@ -107,8 +112,9 @@ describe('Requests', () => {
   describe('fromWsRequest', () => {
     it('should parse url correctly from http IncomingMessage', () => {
       const req = {
-        url: 'api/path1/test?q=1&p=abc'
-      } as IncomingMessage;
+        url: 'api/path1/test?q=1&p=abc',
+        route: { path: '' }
+      } as Request;
 
       const result = fromWsRequest(req, {
         endpoint: 'api/path1/test'
@@ -120,8 +126,9 @@ describe('Requests', () => {
 
     it('should parse url path variables correctly from url', () => {
       const req = {
-        url: '/api/path1/test?q=1&p=abc'
-      } as IncomingMessage;
+        url: '/api/path1/test?q=1&p=abc',
+        route: { path: '' }
+      } as Request;
 
       const result = fromWsRequest(req, {
         endpoint: 'api/:var1/:var2'
@@ -134,8 +141,9 @@ describe('Requests', () => {
     it('should return body and stringBody correctly when message is not given', () => {
       const req = {
         url: 'api/path1/test?q=1&p=abc',
-        body: { a: 1, text: 'hello' }
-      } as IncomingMessage;
+        body: { a: 1, text: 'hello' },
+        route: { path: '' }
+      } as Request;
       const result = fromWsRequest(req, {
         endpoint: 'api/path1/test'
       } as Route);
@@ -149,8 +157,9 @@ describe('Requests', () => {
         body: { a: 1, text: 'hello' },
         headers: {
           'content-type': 'application/json'
-        } as NodeJS.Dict<string | string[]>
-      } as IncomingMessage;
+        } as NodeJS.Dict<string | string[]>,
+        route: { path: '' }
+      } as Request;
       const result = fromWsRequest(
         req,
         {
@@ -168,8 +177,9 @@ describe('Requests', () => {
         headers: {
           'content-type': 'application/json',
           accept: 'text/html'
-        } as NodeJS.Dict<string | string[]>
-      } as IncomingMessage;
+        } as NodeJS.Dict<string | string[]>,
+        route: { path: '' }
+      } as Request;
       const result = fromWsRequest(req, {
         endpoint: 'api/path1/test'
       } as Route);
@@ -187,8 +197,9 @@ describe('Requests', () => {
           accept: 'text/html',
           host: 'localhost',
           'x-forwarded-for': '192.168.1.1'
-        } as NodeJS.Dict<string | string[]>
-      } as IncomingMessage;
+        } as NodeJS.Dict<string | string[]>,
+        route: { path: '' }
+      } as Request;
       const result = fromWsRequest(req, {
         endpoint: 'api/path1/test'
       } as Route);
@@ -200,8 +211,9 @@ describe('Requests', () => {
       const req = {
         headers: {
           cookie: 'a=1;b=hello%20this%20is%20%2521%3D4'
-        }
-      } as IncomingMessage;
+        },
+        route: { path: '' }
+      } as Request;
       const result = fromWsRequest(req, {
         endpoint: 'api/path1/test'
       } as Route);
@@ -218,8 +230,9 @@ describe('Requests', () => {
         url: 'api/path1/test?q=1&p=abc',
         headers: {
           'content-type': 'application/json'
-        } as NodeJS.Dict<string | string[]>
-      } as IncomingMessage;
+        } as NodeJS.Dict<string | string[]>,
+        route: { path: '' }
+      } as Request;
       const req = fromWsRequest(originalReq, {
         endpoint: 'api/path1/test'
       } as Route);
@@ -237,8 +250,9 @@ describe('Requests', () => {
           url: 'api/path1/test?q=1&p=abc',
           headers: {
             'content-type': 'application/json'
-          } as NodeJS.Dict<string | string[]>
-        } as IncomingMessage,
+          } as NodeJS.Dict<string | string[]>,
+          route: { path: '' }
+        } as Request,
         {
           endpoint: 'api/path1/test'
         } as Route
@@ -256,8 +270,9 @@ describe('Requests', () => {
           body: { a: 1, text: 'hello' },
           headers: {
             'content-type': 'application/json'
-          } as NodeJS.Dict<string | string[]>
-        } as IncomingMessage,
+          } as NodeJS.Dict<string | string[]>,
+          route: { path: '' }
+        } as Request,
         {
           endpoint: 'api/path1/test'
         } as Route
@@ -284,8 +299,9 @@ describe('Requests', () => {
           stringBody: JSON.stringify({ a: 1, text: 'hello' }),
           headers: {
             'content-type': 'application/json'
-          } as NodeJS.Dict<string | string[]>
-        } as IncomingMessage,
+          } as NodeJS.Dict<string | string[]>,
+          route: { path: '' }
+        } as Request,
         {
           endpoint: 'api/path1/test'
         } as Route

--- a/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
+++ b/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
@@ -1996,7 +1996,8 @@ describe('Response rules interpreter', () => {
         header: function (_headerName: string) {
           return '';
         },
-        url: '/test/1'
+        url: '/test/1',
+        route: { path: '/test/:id' }
       } as Request;
 
       const routeResponse = new ResponseRulesInterpreter(
@@ -2026,12 +2027,49 @@ describe('Response rules interpreter', () => {
       strictEqual(routeResponse?.body, 'path1');
     });
 
+    it('should return response if path equals value', () => {
+      const request: Request = {
+        header: function (_headerName: string) {
+          return '';
+        },
+        url: '/test/1',
+        route: { path: '/test/:id' }
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'path',
+                modifier: '',
+                value: '/test/:id',
+                operator: 'equals',
+                invert: false
+              }
+            ],
+            body: 'path1'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'path1');
+    });
+
     it('should return response if path contains value (regex)', () => {
       const request: Request = {
         header: function (_headerName: string) {
           return '';
         },
-        url: '/test/2'
+        url: '/test/2',
+        route: { path: '/test/:id' }
       } as Request;
 
       const routeResponse = new ResponseRulesInterpreter(
@@ -2044,6 +2082,42 @@ describe('Response rules interpreter', () => {
                 target: 'path',
                 modifier: '',
                 value: '1|2',
+                operator: 'regex',
+                invert: false
+              }
+            ],
+            body: 'path2'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'path2');
+    });
+
+    it('should return response if path contains value (regex)', () => {
+      const request: Request = {
+        header: function (_headerName: string) {
+          return '';
+        },
+        url: '/test/2',
+        route: { path: '/test/:id' }
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'path',
+                modifier: '',
+                value: ':id',
                 operator: 'regex',
                 invert: false
               }

--- a/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
+++ b/packages/desktop/src/renderer/app/components/route-response-rules/route-response-rules.component.ts
@@ -106,8 +106,8 @@ export class RouteResponseRulesComponent implements OnInit, OnDestroy {
     ],
     cookie: ['empty_array'],
     params: ['empty_array', 'array_includes'],
-    path: ['null', 'empty_array', 'array_includes'],
-    method: ['null', 'empty_array', 'array_includes'],
+    path: ['null', 'empty_array', 'array_includes', 'valid_json_schema'],
+    method: ['null', 'empty_array', 'array_includes', 'valid_json_schema'],
     templating: ['empty_array', 'array_includes']
   };
   public rulesOperators: ToggleItems = [


### PR DESCRIPTION
Path rule can now compare the value against the original path (/test/:id) and the effective path (/test/123).

Closes #1605

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
