### PR TITLE
Add support for multipart/form-data arrays without using the brackets

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -400,6 +400,15 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
             }
 
             if (name != null && !info.nameTruncated && !info.valueTruncated) {
+              // add support for first level array fields (e.g. multiple fields with the same name without brackets)
+              if (
+                !name.includes('[') &&
+                request.body[name] !== undefined &&
+                !Array.isArray(request.body[name])
+              ) {
+                request.body[name] = [request.body[name]];
+                name = `${name}[]`;
+              }
               appendField(request.body, name, value);
             }
           });
@@ -426,6 +435,16 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               });
 
               stream.on('close', () => {
+                // add support for first level array fields (e.g. multiple fields with the same name without brackets)
+                if (
+                  !name.includes('[') &&
+                  request.body[name] !== undefined &&
+                  !Array.isArray(request.body[name])
+                ) {
+                  request.body[name] = [request.body[name]];
+                  name = `${name}[]`;
+                }
+
                 appendField(request.body, name, file);
               });
             }

--- a/packages/commons-server/test/specs/server/server-body-parsing.test.ts
+++ b/packages/commons-server/test/specs/server/server-body-parsing.test.ts
@@ -1,0 +1,162 @@
+import { BodyTypes, Environment, RouteType } from '@mockoon/commons';
+import { deepEqual } from 'node:assert';
+import { after, before, describe, it } from 'node:test';
+import { MockoonServer } from '../../../src';
+
+describe('Server body parsing', () => {
+  const environment: Environment = {
+    uuid: 'c6199444-5116-490a-99a2-074876253a4a',
+    lastMigration: 32,
+    name: 'Test env',
+    port: 3010,
+    hostname: '',
+    endpointPrefix: '',
+    latency: 0,
+    routes: [
+      {
+        uuid: '85e236c4-decc-467c-b288-d243181a250f',
+        documentation: 'doc',
+        method: 'post',
+        endpoint: 'test',
+        responses: [
+          {
+            uuid: 'cd4eb020-310f-4bca-adda-98410cf65a62',
+            rules: [],
+            rulesOperator: 'OR',
+            statusCode: 200,
+            label: 'Route',
+            headers: [],
+            latency: 0,
+            filePath: '',
+            sendFileAsBody: false,
+            disableTemplating: false,
+            fallbackTo404: false,
+            body: '{{{stringify (bodyRaw)}}}',
+            default: true,
+            databucketID: '',
+            bodyType: BodyTypes.INLINE,
+            crudKey: 'id',
+            callbacks: []
+          }
+        ],
+        responseMode: null,
+        type: RouteType.HTTP,
+        streamingInterval: 0,
+        streamingMode: null
+      }
+    ],
+    proxyMode: false,
+    proxyRemovePrefix: false,
+    proxyHost: '',
+    proxyReqHeaders: [],
+    proxyResHeaders: [],
+    cors: false,
+    headers: [
+      {
+        key: 'Content-Type',
+        value: 'application/json'
+      }
+    ],
+    tlsOptions: {
+      enabled: false,
+      type: 'CERT',
+      pfxPath: '',
+      certPath: '',
+      keyPath: '',
+      caPath: '',
+      passphrase: ''
+    },
+    data: [],
+    folders: [],
+    rootChildren: [
+      {
+        type: 'route',
+        uuid: '85e236c4-decc-467c-b288-d243181a250f'
+      }
+    ],
+    callbacks: []
+  };
+
+  describe('Multipart form data', () => {
+    let server: MockoonServer;
+
+    before((_context, done) => {
+      server = new MockoonServer(environment);
+
+      server.on('started', () => {
+        done();
+      });
+
+      server.start();
+    });
+
+    it('should parse a multipart form data request body with single field and file', async () => {
+      const formData = new FormData();
+      formData.set('field1', 'value1');
+      formData.set(
+        'file1',
+        new Blob(['file1 content'], { type: 'text/plain' }),
+        'file1.txt'
+      );
+
+      const data = await (
+        await fetch('http://localhost:3010/test', {
+          method: 'POST',
+          body: formData
+        })
+      ).json();
+
+      deepEqual(data, {
+        field1: 'value1',
+        file1: {
+          filename: 'file1.txt',
+          mimetype: 'text/plain',
+          size: 13
+        }
+      });
+    });
+
+    it('should parse a multipart form data request body with fields and files (arrays)', async () => {
+      const formData = new FormData();
+      formData.set('fields', 'value2');
+      formData.append('fields', 'value3');
+      formData.set(
+        'files',
+        new Blob(['file2 content'], { type: 'text/plain' }),
+        'file2.txt'
+      );
+      formData.append(
+        'files',
+        new Blob(['file3 content'], { type: 'text/plain' }),
+        'file3.txt'
+      );
+
+      const data = await (
+        await fetch('http://localhost:3010/test', {
+          method: 'POST',
+          body: formData
+        })
+      ).json();
+
+      deepEqual(data, {
+        fields: ['value2', 'value3'],
+        files: [
+          {
+            filename: 'file2.txt',
+            mimetype: 'text/plain',
+            size: 13
+          },
+          {
+            filename: 'file3.txt',
+            mimetype: 'text/plain',
+            size: 13
+          }
+        ]
+      });
+    });
+
+    after(() => {
+      server.stop();
+    });
+  });
+});


### PR DESCRIPTION
Multiple fields having the same names without brackets are now stored as an array Closes #1613

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
