### PR TITLE
Fix websockets hanging when API prefix is present

### DIFF
--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -42,6 +42,7 @@
         "@types/node": "22.7.9",
         "@types/object-path": "0.11.4",
         "@types/qs": "6.9.16",
+        "@types/ws": "8.5.13",
         "openapi-types": "12.1.3",
         "typescript": "5.6.3"
       },
@@ -333,6 +334,15 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/packages/commons-server/package.json
+++ b/packages/commons-server/package.json
@@ -65,6 +65,7 @@
     "@types/node": "22.7.9",
     "@types/object-path": "0.11.4",
     "@types/qs": "6.9.16",
+    "@types/ws": "8.5.13",
     "openapi-types": "12.1.3",
     "typescript": "5.6.3"
   }

--- a/packages/commons-server/test/specs/server/ws.test.ts
+++ b/packages/commons-server/test/specs/server/ws.test.ts
@@ -5,7 +5,7 @@ import {
   Route,
   RouteResponse
 } from '@mockoon/commons';
-import { IncomingMessage } from 'http';
+import { Request } from 'express';
 import { ok, strictEqual } from 'node:assert';
 import { describe, it } from 'node:test';
 import { fromWsRequest } from '../../../src/libs/requests';
@@ -33,7 +33,7 @@ const EMPTY_SERVER_CTX = {
 } as ServerContext;
 
 const EMPTY_WS_REQUEST = fromWsRequest(
-  {} as IncomingMessage,
+  {} as Request,
   {
     endpoint: 'api/path1/test'
   } as Route

--- a/packages/desktop/test/data/mock-envs/ws.json
+++ b/packages/desktop/test/data/mock-envs/ws.json
@@ -2,10 +2,41 @@
   "uuid": "323a25c6-b196-4d27-baf8-8aeb83d87c76",
   "lastMigration": 33,
   "name": "WebSockets Test",
-  "endpointPrefix": "",
+  "endpointPrefix": "ws-env",
   "latency": 0,
   "port": 3000,
   "routes": [
+    {
+      "uuid": "a9bf1b7f-b829-4f18-9763-fd3a635abe75",
+      "type": "http",
+      "documentation": "HTTP route with same endpoint as ws route",
+      "method": "get",
+      "endpoint": "test/ws/echo",
+      "responses": [
+        {
+          "uuid": "363474ea-0e3e-47e2-b6b0-42506232bd0d",
+          "body": "httpres",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
     {
       "uuid": "dd07b407-df1f-4393-83f2-7a832fdd6f99",
       "method": "get",
@@ -427,6 +458,7 @@
   ],
   "folders": [],
   "rootChildren": [
+    { "type": "route", "uuid": "a9bf1b7f-b829-4f18-9763-fd3a635abe75" },
     { "type": "route", "uuid": "06441476-6e46-4763-a8e7-0cc8377efb3a" },
     { "type": "route", "uuid": "12c2e169-2211-4582-85bc-82caaa8e4390" },
     { "type": "route", "uuid": "dd07b407-df1f-4393-83f2-7a832fdd6f99" },

--- a/packages/desktop/test/specs/ws.spec.ts
+++ b/packages/desktop/test/specs/ws.spec.ts
@@ -14,21 +14,32 @@ describe('WebSockets', () => {
   });
 
   describe('Http and WebSocket mixed', () => {
-    it('should work http routes as usual among websocket routes', async () => {
+    it('should get response from http routes as usual among websocket routes', async () => {
       await http.assertCall({
         method: 'GET',
-        path: '/test/http',
+        path: '/ws-env/test/http',
         testedResponse: {
           status: 200,
           body: 'This is a http response'
         }
       });
     });
+
+    it('should get response from http routes with same name than a ws route', async () => {
+      await http.assertCall({
+        method: 'GET',
+        path: '/ws-env/test/ws/echo',
+        testedResponse: {
+          status: 200,
+          body: 'httpres'
+        }
+      });
+    });
   });
 
   describe('One-to-one websocket', () => {
-    it('Should be able to connect to echo websocket service', async () => {
-      const ws = new WsConnection(3000, '/test/ws/echo');
+    it('should be able to connect to echo websocket service', async () => {
+      const ws = new WsConnection(3000, '/ws-env/test/ws/echo');
       await ws.openForConversation();
       ws.assertWebsocketIsOpened();
 
@@ -46,11 +57,11 @@ describe('WebSockets', () => {
     });
 
     it('should be able to connect multiple clients to echo socket', async () => {
-      const ws1 = new WsConnection(3000, '/test/ws/echo');
+      const ws1 = new WsConnection(3000, '/ws-env/test/ws/echo');
       await ws1.openForConversation();
       ws1.assertWebsocketIsOpened();
 
-      const ws2 = new WsConnection(3000, '/test/ws/echo');
+      const ws2 = new WsConnection(3000, '/ws-env/test/ws/echo');
       await ws2.openForConversation();
       await ws2.assertWebsocketIsOpened();
 
@@ -85,7 +96,7 @@ describe('WebSockets', () => {
         './tmp/storage/file-templating.txt'
       );
 
-      const ws = new WsConnection(3000, '/test/ws/converse');
+      const ws = new WsConnection(3000, '/ws-env/test/ws/converse');
       await ws.openForConversation({
         'Content-Type': 'application/json'
       });
@@ -100,8 +111,11 @@ describe('WebSockets', () => {
       ws.assertWebsocketIsClosed();
     });
 
-    it('Should be able to connect to streaming websocket service', async () => {
-      const ws = new WsConnection(3000, '/test/ws/one-to-one?q1=abc&q2=123');
+    it('should be able to connect to streaming websocket service', async () => {
+      const ws = new WsConnection(
+        3000,
+        '/ws-env/test/ws/one-to-one?q1=abc&q2=123'
+      );
       await ws.open();
       ws.assertWebsocketIsOpened();
 
@@ -121,8 +135,8 @@ describe('WebSockets', () => {
       ws.assertWebsocketIsClosed();
     });
 
-    it('Should send data in correct order for sequential streaming', async () => {
-      const ws = new WsConnection(3000, '/test/ws/one-to-one/seq');
+    it('should send data in correct order for sequential streaming', async () => {
+      const ws = new WsConnection(3000, '/ws-env/test/ws/one-to-one/seq');
       await ws.open();
       ws.assertWebsocketIsOpened();
 
@@ -139,8 +153,8 @@ describe('WebSockets', () => {
       ws.assertWebsocketIsClosed();
     });
 
-    it('Should send correct data for default response streaming', async () => {
-      const ws = new WsConnection(3000, '/test/ws/one-to-one/dfres');
+    it('should send correct data for default response streaming', async () => {
+      const ws = new WsConnection(3000, '/ws-env/test/ws/one-to-one/dfres');
       await ws.open();
       ws.assertWebsocketIsOpened();
 
@@ -157,7 +171,7 @@ describe('WebSockets', () => {
     });
 
     it('should not be able to connect to disabled websockets', async () => {
-      const ws = new WsConnection(3000, '/test/ws/disabled');
+      const ws = new WsConnection(3000, '/ws-env/test/ws/disabled');
       try {
         await withTimeout(5000, ws.open());
         fail();
@@ -167,8 +181,8 @@ describe('WebSockets', () => {
 
   describe('Broadcast streams', () => {
     it('should receive same message for all connected clients', async () => {
-      const ws1 = new WsConnection(3000, '/test/ws/broadcast');
-      const ws2 = new WsConnection(3000, '/test/ws/broadcast');
+      const ws1 = new WsConnection(3000, '/ws-env/test/ws/broadcast');
+      const ws2 = new WsConnection(3000, '/ws-env/test/ws/broadcast');
       await Promise.all([ws1.open(), ws2.open()]);
       ws1.assertWebsocketIsOpened();
       ws2.assertWebsocketIsOpened();
@@ -214,7 +228,7 @@ describe('WebSockets', () => {
     });
 
     it('should be able to connect to secured websocket', async () => {
-      const ws = new WsConnection(3000, '/test/ws/echo', 'wss');
+      const ws = new WsConnection(3000, '/ws-env/test/ws/echo', 'wss');
       await ws.openForConversation();
       ws.assertWebsocketIsOpened();
 


### PR DESCRIPTION
WS connections were hanging when the wrong path was provided, or when an API prefix was present. Also fixes a mistake where an HTTP route was always created with the same name as the WS route. Closes #1612

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [x] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
