### PR TITLE
Add objectMerge helper, add array support in concat and setData 'merge'

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
@@ -94,7 +94,7 @@ export const DataHelpers = function (
         return;
       }
 
-      const operators = ['push', 'del', 'inc', 'dec', 'invert', 'set'];
+      const operators = ['push', 'del', 'inc', 'dec', 'invert', 'set', 'merge'];
       let operator = String(fromSafeString(parameters[0]));
 
       // default operator is 'set'
@@ -122,6 +122,37 @@ export const DataHelpers = function (
           objectSet(targetDatabucket.value, path, newValue);
         } else {
           targetDatabucket.value = newValue;
+        }
+      } else if (operator === 'merge') {
+        const currentValue = path
+          ? objectGet(targetDatabucket.value, path)
+          : targetDatabucket.value;
+
+        if (
+          typeof currentValue === 'object' &&
+          !Array.isArray(currentValue) &&
+          currentValue !== null &&
+          typeof newValue === 'object' &&
+          !Array.isArray(newValue) &&
+          newValue !== null
+        ) {
+          if (path) {
+            objectSet(targetDatabucket.value, path, {
+              ...currentValue,
+              ...newValue
+            });
+          } else {
+            targetDatabucket.value = {
+              ...currentValue,
+              ...newValue
+            };
+          }
+        } else {
+          if (path) {
+            objectSet(targetDatabucket.value, path, newValue);
+          } else {
+            targetDatabucket.value = newValue;
+          }
         }
       } else if (operator === 'push') {
         if (path && Array.isArray(objectGet(targetDatabucket.value, path))) {

--- a/packages/commons-server/src/libs/templating-helpers/helpers/concat.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/concat.ts
@@ -1,9 +1,20 @@
-// concat multiple string and/or variables (like @index)
+// concat multiple string and/or variables (like @index), or arrays
 const concat = function (...args: any[]) {
   // remove handlebars options
-  const toConcat = args.slice(0, args.length - 1);
+  const parameters = args.slice(0, args.length - 1);
 
-  return toConcat.join('');
+  const isArray = Array.isArray(parameters[0]);
+
+  return parameters.reduce(
+    (result, parameter) => {
+      if (isArray) {
+        return result.concat(parameter);
+      } else {
+        return `${result}${parameter}`;
+      }
+    },
+    isArray ? [] : ''
+  );
 };
 
 export default concat;

--- a/packages/commons-server/src/libs/templating-helpers/helpers/index.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/index.ts
@@ -64,6 +64,7 @@ import newline from './newline';
 import now from './now';
 import object from './object';
 import objectId from './objectId';
+import objectMerge from './objectMerge';
 import oneOf from './oneOf';
 import padEnd from './padEnd';
 import padStart from './padStart';
@@ -149,6 +150,7 @@ export const Helpers = {
   now,
   object,
   objectId,
+  objectMerge,
   oneOf,
   padEnd,
   padStart,

--- a/packages/commons-server/src/libs/templating-helpers/helpers/objectMerge.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/objectMerge.ts
@@ -1,0 +1,23 @@
+const objectMerge = function (...args: any[]) {
+  const parameters = args.slice(0, -1);
+
+  if (parameters.length === 0) {
+    return '';
+  }
+
+  let result = {};
+
+  parameters.forEach((parameter) => {
+    if (
+      typeof parameter === 'object' &&
+      !Array.isArray(parameter) &&
+      parameter !== null
+    ) {
+      result = { ...result, ...parameter };
+    }
+  });
+
+  return result;
+};
+
+export default objectMerge;

--- a/packages/commons-server/src/libs/utils.ts
+++ b/packages/commons-server/src/libs/utils.ts
@@ -245,13 +245,13 @@ export const FromBase64 = (base64: string): string =>
   Buffer.from(base64, 'base64').toString('utf-8');
 
 /**
- * Convert a SafeString to a string if needed.
+ * Extract the string value from a SafeString
  *
- * @param text
+ * @param value
  * @returns
  */
-export const fromSafeString = (text: string | SafeString) =>
-  text instanceof SafeString ? text.toString() : text;
+export const fromSafeString = (value: any | SafeString) =>
+  value instanceof SafeString ? value.toString() : value;
 
 /**
  * Parse a number from a SafeString if needed.

--- a/packages/commons-server/test/specs/templating-helpers/data-helpers.test.ts
+++ b/packages/commons-server/test/specs/templating-helpers/data-helpers.test.ts
@@ -1337,5 +1337,95 @@ describe('Data helpers', () => {
       });
       strictEqual(parseResult, 'false');
     });
+
+    it('should merge objects when no path is provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content:
+          '{{setData "merge" "myData" null (object type="test")}}{{data "myData"}}',
+        environment: {} as any,
+        processedDatabuckets: [
+          {
+            name: 'myData',
+            id: 'abcd',
+            value: { id: 123 },
+            parsed: true,
+            uuid: '463c6d7c-c597-4d4b-a0c3-803356c67e5a',
+            validJson: true
+          }
+        ],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, '{"id":123,"type":"test"}');
+    });
+
+    it('should merge objects when a path is provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content:
+          '{{setData "merge" "myData" "sub" (object type="test")}}{{data "myData"}}',
+        environment: {} as any,
+        processedDatabuckets: [
+          {
+            name: 'myData',
+            id: 'abcd',
+            value: { sub: { id: 123 } },
+            parsed: true,
+            uuid: '463c6d7c-c597-4d4b-a0c3-803356c67e5a',
+            validJson: true
+          }
+        ],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, '{"sub":{"id":123,"type":"test"}}');
+    });
+
+    it('should not merge objects, but replace bucket value when new value is not an object and no path is provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{setData "merge" "myData" null "hello"}}{{data "myData"}}',
+        environment: {} as any,
+        processedDatabuckets: [
+          {
+            name: 'myData',
+            id: 'abcd',
+            value: { id: 123 },
+            parsed: true,
+            uuid: '463c6d7c-c597-4d4b-a0c3-803356c67e5a',
+            validJson: true
+          }
+        ],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, 'hello');
+    });
+
+    it('should not merge objects, but create new entry (using object path) when new value is not an object and a path is provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{setData "merge" "myData" "sub" "hello"}}{{data "myData"}}',
+        environment: {} as any,
+        processedDatabuckets: [
+          {
+            name: 'myData',
+            id: 'abcd',
+            value: { id: 123 },
+            parsed: true,
+            uuid: '463c6d7c-c597-4d4b-a0c3-803356c67e5a',
+            validJson: true
+          }
+        ],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, '{"id":123,"sub":"hello"}');
+    });
   });
 });

--- a/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
+++ b/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
@@ -151,6 +151,23 @@ describe('Template parser', () => {
       });
       strictEqual(parseResult, 'item_10item_20');
     });
+
+    it('should concat arrays', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content:
+          "{{{stringify (concat (array 'item1' 'item2') (array 'item3' 'item4') (array 'item5'))}}}",
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(
+        parseResult,
+        '[\n  "item1",\n  "item2",\n  "item3",\n  "item4",\n  "item5"\n]'
+      );
+    });
   });
 
   describe('Helper: setVar', () => {
@@ -2617,7 +2634,9 @@ describe('Template parser', () => {
             parsed: true,
             value: {
               myarr: [1, 2, 3]
-            }
+            },
+            uuid: '',
+            validJson: true
           }
         ],
         globalVariables: {},
@@ -2914,7 +2933,9 @@ describe('Template parser', () => {
             id: 'abc1',
             name: 'db1',
             parsed: true,
-            value: [{ id: 1, value: 'value1' }]
+            value: [{ id: 1, value: 'value1' }],
+            uuid: '',
+            validJson: true
           }
         ],
         globalVariables: {},
@@ -2934,7 +2955,9 @@ describe('Template parser', () => {
             id: 'abc1',
             name: 'db1',
             parsed: true,
-            value: [{ id: 1, value: 'value1' }]
+            value: [{ id: 1, value: 'value1' }],
+            uuid: '',
+            validJson: true
           }
         ],
         globalVariables: {},
@@ -2995,6 +3018,34 @@ describe('Template parser', () => {
           2
         )
       );
+    });
+  });
+
+  describe('Helper: objectMerge', () => {
+    it('should return nothing when no parameter provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{{ stringify (objectMerge) }}}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: { body: { test: 'value' } } as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, '');
+    });
+
+    it('should return a new object after merging multiple parameters', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{{ stringify (objectMerge (object id=12) (bodyRaw)) }}}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: { body: { test: 'value' } } as any,
+        envVarsPrefix: ''
+      });
+      strictEqual(parseResult, '{\n  "id": 12,\n  "test": "value"\n}');
     });
   });
 

--- a/packages/desktop/src/renderer/app/constants/autocomplete.constant.ts
+++ b/packages/desktop/src/renderer/app/constants/autocomplete.constant.ts
@@ -59,6 +59,7 @@ export const helpersAutocompletions = [
   { caption: 'base64', value: '{{base64 value}}', meta: '' },
   { caption: 'base64Decode', value: '{{base64Decode string}}', meta: '' },
   { caption: 'objectId', value: '{{objectId}}', meta: '' },
+  { caption: 'objectMerge', value: '{{objectMerge object object}}', meta: '' },
   { caption: 'getVar', value: "{{getVar 'varname'}}", meta: '' },
   { caption: 'setVar', value: "{{setVar 'varname' 'value'}}", meta: '' },
   {


### PR DESCRIPTION
Closes #1620

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
