### PR TITLE
Fix rules not able to target full targets (root level, no modifier)

### DIFF
--- a/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
+++ b/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
@@ -2675,6 +2675,84 @@ describe('Response rules interpreter', () => {
     const xmlBody =
       '<?xml version="1.0" encoding="utf-8"?><user userId="1"><name>John</name></user>';
 
+    it('should return response if full body is null (req content type absent)', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = {};
+
+          return headers[headerName];
+        },
+        stringBody: '',
+        body: ''
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: '',
+                operator: 'null',
+                invert: false
+              }
+            ],
+            body: 'body1'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'body1');
+    });
+
+    it('should return response if full body is null (req content type present)', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = {
+            'Content-Type': 'application/json'
+          };
+
+          return headers[headerName];
+        },
+        stringBody: '',
+        body: ''
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: '',
+                operator: 'null',
+                invert: false
+              }
+            ],
+            body: 'body1'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'body1');
+    });
+
     it('should return response if full body value matches (no modifier + regex)', () => {
       const request: Request = {
         header: function (headerName: string) {
@@ -4200,6 +4278,82 @@ describe('Response rules interpreter', () => {
         ''
       ).chooseResponse(1);
       strictEqual(routeResponse?.body, 'unauthorized');
+    });
+
+    it('should return response if operator is "empty_array" and body property is an empty array', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = { 'Content-Type': 'application/json' };
+
+          return headers[headerName];
+        },
+        body: {
+          prop: []
+        }
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'body',
+                modifier: 'prop',
+                value: '',
+                operator: 'empty_array',
+                invert: false
+              }
+            ],
+            body: 'response1'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'response1');
+    });
+
+    it('should return response if operator is "empty_array" and body is an empty array', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = { 'Content-Type': 'application/json' };
+
+          return headers[headerName];
+        },
+        body: []
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'body',
+                modifier: '',
+                value: '',
+                operator: 'empty_array',
+                invert: false
+              }
+            ],
+            body: 'response1'
+          }
+        ],
+        fromExpressRequest(request),
+        null,
+        EnvironmentDefault,
+        [],
+        {},
+        ''
+      ).chooseResponse(1);
+      strictEqual(routeResponse?.body, 'response1');
     });
   });
 


### PR DESCRIPTION
Null and empty array rules were needing a modifier to work, which doesn't really make sense. Also, the default body string value was removed if the request contains a valid content type, even if parsing wasn't successful. Closes #1628

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/desktop)

<!-- Link to the original issue -->

Closes #{issue_number}
