### PR TITLE
Improve desktop local and cloud instances running state

### DIFF
--- a/packages/app/src/renderer/app/components/environment-settings/environment-settings.component.ts
+++ b/packages/app/src/renderer/app/components/environment-settings/environment-settings.component.ts
@@ -82,7 +82,9 @@ export class EnvironmentSettingsComponent implements OnInit, OnDestroy {
             deployInstance.environmentUuid === environment.uuid
         );
 
-        return buildApiUrl(environment, instance);
+        const urls = buildApiUrl({ environment, instance });
+
+        return this.isWeb ? urls.webUrl : urls.localUrl;
       })
     );
     this.initForms();

--- a/packages/app/src/renderer/app/components/header/header.component.html
+++ b/packages/app/src/renderer/app/components/header/header.component.html
@@ -7,73 +7,114 @@
 
 <div class="header d-flex align-items-center">
   <div appTourStep="tour-environment-start">
-    @if (
-      isWeb &&
-      activeEnvironmentState?.running &&
-      activeEnvironmentState?.needRestart &&
-      activeEnvironmentState?.redeploying
-    ) {
-      <button
-        class="btn btn-link btn-icon text-gray"
-        type="button"
-        ngbTooltip="Re-deploy in progress"
-      >
-        <app-svg icon="spinner" size="20"></app-svg>
-      </button>
-    } @else if (
-      activeEnvironmentState?.running &&
-      activeEnvironmentState?.needRestart &&
-      !activeEnvironmentState?.redeploying
-    ) {
-      <button
-        id="header-btn-server-restart"
-        class="btn btn-link text-warning"
-        type="button"
-        [ngbTooltip]="
-          isWeb ? 'Quick re-deploy to apply changes' : 'Server needs restart'
-        "
-        (click)="
-          toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
-        "
-        [disabled]="!activeEnvironment"
-      >
-        <app-svg icon="refresh" size="20"></app-svg>
-      </button>
-    } @else if (
-      activeEnvironmentState?.running && !activeEnvironmentState?.needRestart
-    ) {
-      <button
-        id="header-btn-server-stop"
-        class="btn btn-link"
-        type="button"
-        [ngClass]="{
-          'text-danger': !isWeb,
-          'text-success': isWeb
-        }"
-        [ngbTooltip]="isWeb ? 'Manage deployment' : 'Stop server'"
-        (click)="
-          toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
-        "
-        [disabled]="!activeEnvironment"
-      >
-        <app-svg
-          [icon]="isWeb ? 'server_settings' : 'stop'"
-          size="20"
-        ></app-svg>
-      </button>
-    } @else if (!activeEnvironmentState?.running) {
-      <button
-        id="header-btn-server-start"
-        class="btn btn-link text-success"
-        type="button"
-        [ngbTooltip]="isWeb ? 'Deploy API' : 'Start server'"
-        (click)="
-          toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
-        "
-        [disabled]="!activeEnvironment"
-      >
-        <app-svg icon="play_arrow" size="20"></app-svg>
-      </button>
+    <!-- Web interface is focused on deploying to the cloud and managing the instance -->
+    @if (isWeb) {
+      @if (
+        activeEnvironmentState?.running &&
+        activeEnvironmentState?.needRestart &&
+        activeEnvironmentState?.redeploying
+      ) {
+        <button
+          class="btn btn-link btn-icon text-gray"
+          type="button"
+          ngbTooltip="Re-deploy in progress"
+        >
+          <app-svg icon="spinner" size="20"></app-svg>
+        </button>
+      } @else if (
+        activeEnvironmentState?.running &&
+        activeEnvironmentState?.needRestart &&
+        !activeEnvironmentState?.redeploying
+      ) {
+        <button
+          id="header-btn-server-restart"
+          class="btn btn-link text-warning"
+          type="button"
+          ngbTooltip="Quick re-deploy to apply changes"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="refresh" size="20"></app-svg>
+        </button>
+      } @else if (
+        activeEnvironmentState?.running && !activeEnvironmentState?.needRestart
+      ) {
+        <button
+          id="header-btn-server-stop"
+          class="btn btn-link text-success"
+          type="button"
+          ngbTooltip="Manage deployment"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="server_settings" size="20"></app-svg>
+        </button>
+      } @else if (!activeEnvironmentState?.running) {
+        <button
+          id="header-btn-server-start"
+          class="btn btn-link text-success"
+          type="button"
+          ngbTooltip="Deploy API"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="play_arrow" size="20"></app-svg>
+        </button>
+      }
+    } @else {
+      <!--  Desktop interface is focused on running the mock locally -->
+      @if (
+        activeEnvironmentState?.running &&
+        activeEnvironmentState?.needRestart &&
+        !activeEnvironmentState?.redeploying
+      ) {
+        <button
+          id="header-btn-server-restart"
+          class="btn btn-link text-warning"
+          type="button"
+          ngbTooltip="Local server needs restart"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="refresh" size="20"></app-svg>
+        </button>
+      } @else if (
+        activeEnvironmentState?.running && !activeEnvironmentState?.needRestart
+      ) {
+        <button
+          id="header-btn-server-stop"
+          class="btn btn-link text-danger"
+          type="button"
+          ngbTooltip="Stop local server"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="stop" size="20"></app-svg>
+        </button>
+      } @else if (!activeEnvironmentState?.running) {
+        <button
+          id="header-btn-server-start"
+          class="btn btn-link text-success"
+          type="button"
+          ngbTooltip="Start local server"
+          (click)="
+            toggleEnvironment(activeEnvironment.uuid, activeEnvironmentState)
+          "
+          [disabled]="!activeEnvironment"
+        >
+          <app-svg icon="play_arrow" size="20"></app-svg>
+        </button>
+      }
     }
   </div>
 

--- a/packages/app/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
+++ b/packages/app/src/renderer/app/components/menus/environments-menu/environments-menu.component.html
@@ -217,11 +217,7 @@
           <a
             class="nav-link d-flex pe-0 hover-parent"
             [ngClass]="{
-              active: activeEnvironment?.uuid === environment.uuid,
-              running:
-                environmentsStatus[environment.uuid]?.running &&
-                !environmentsStatus[environment.uuid]?.needRestart,
-              'need-restart': environmentsStatus[environment.uuid]?.needRestart
+              active: activeEnvironment?.uuid === environment.uuid
             }"
             appScrollWhenActive
             (click)="selectEnvironment(environment.uuid)"
@@ -245,64 +241,179 @@
                 ></app-editable-element>
               </div>
 
-              <div
-                class="nav-link-subtitle mt-1 d-flex align-items-center svg-text-align"
-              >
-                @if (!isWeb && instances[environment.uuid]) {
+              @if (isWeb) {
+                <div
+                  class="nav-link-subtitle mt-1 d-flex align-items-center svg-text-align"
+                >
                   <app-svg
                     class="me-2"
                     [ngClass]="{
                       'text-success':
                         instances[environment.uuid]?.status === 'RUNNING',
-                      'text-danger':
-                        instances[environment.uuid]?.status === 'STOPPED'
+                      'text-muted':
+                        instances[environment.uuid]?.status !== 'RUNNING'
                     }"
-                    icon="record"
+                    icon="cloud"
                     size="12"
                     [ngbTooltip]="
                       instances[environment.uuid]?.status === 'RUNNING'
-                        ? 'Instance running'
-                        : 'Instance stopped'
+                        ? 'Cloud instance running'
+                        : 'Cloud instance stopped'
                     "
                   ></app-svg>
-                }
-                <!-- No need to display TLS indicator on web -->
-                @if (environment.tlsOptions.enabled && !isWeb) {
-                  <app-svg
-                    class="text-warning me-2"
-                    icon="lock"
-                    size="12"
-                    ngbTooltip="TLS enabled"
-                  ></app-svg>
-                }
-                @if (environment.proxyMode) {
-                  <app-svg
-                    class="text-primary me-2"
-                    icon="security"
-                    size="12"
-                    ngbTooltip="Proxy mode enabled"
-                  ></app-svg>
-                }
-                @if ((logsRecording$ | async)[environment.uuid] === true) {
-                  <app-svg
-                    class="text-danger animation-flash me-2"
-                    icon="record"
-                    size="12"
-                    ngbTooltip="Recording in progress"
-                  ></app-svg>
-                }
-                <!-- display url on desktop or on web when instance is running -->
-                @if (!isWeb || instanceUrls[environment.uuid]) {
-                  <span class="text-truncate pe-1">
-                    {{
-                      instanceUrls[environment.uuid] +
-                        (environment?.endpointPrefix
-                          ? '/' + environment?.endpointPrefix
-                          : '')
-                    }}
+                  @if (environment.proxyMode) {
+                    <app-svg
+                      class="text-primary me-2"
+                      icon="security"
+                      size="12"
+                      ngbTooltip="Proxy mode enabled"
+                    ></app-svg>
+                  }
+                  @if ((logsRecording$ | async)[environment.uuid] === true) {
+                    <app-svg
+                      class="text-danger animation-flash me-2"
+                      icon="record"
+                      size="12"
+                      ngbTooltip="Recording in progress"
+                    ></app-svg>
+                  }
+                  @let webUrl =
+                    instanceUrls[environment.uuid].webUrl +
+                    (environment?.endpointPrefix
+                      ? '/' + environment?.endpointPrefix
+                      : '');
+                  <span
+                    class="text-truncate pe-1"
+                    (click)="
+                      copyUrlToClipboard(
+                        environment,
+                        instances[environment.uuid],
+                        'webUrl'
+                      )
+                    "
+                    ngbTooltip="Click to copy"
+                  >
+                    {{ webUrl }}
                   </span>
+                </div>
+              } @else {
+                <div
+                  class="nav-link-subtitle mt-1 d-flex align-items-center svg-text-align"
+                >
+                  <!-- Display local server URL and status on desktop -->
+                  @if (environmentsStatus[environment.uuid]) {
+                    <app-svg
+                      class="me-2"
+                      [ngClass]="{
+                        'text-success':
+                          environmentsStatus[environment.uuid]?.running &&
+                          !environmentsStatus[environment.uuid]?.needRestart,
+                        'text-muted':
+                          !environmentsStatus[environment.uuid]?.running,
+                        'text-orange':
+                          environmentsStatus[environment.uuid]?.needRestart
+                      }"
+                      icon="computer"
+                      size="12"
+                      [ngbTooltip]="
+                        environmentsStatus[environment.uuid]?.running &&
+                        !environmentsStatus[environment.uuid]?.needRestart
+                          ? 'Local server running'
+                          : !environmentsStatus[environment.uuid]?.running
+                            ? 'Local server stopped'
+                            : environmentsStatus[environment.uuid]?.needRestart
+                              ? 'Local server needs restart'
+                              : ''
+                      "
+                    ></app-svg>
+                  }
+                  @if (environment.tlsOptions.enabled) {
+                    <app-svg
+                      class="text-warning me-2"
+                      icon="lock"
+                      size="12"
+                      ngbTooltip="TLS enabled"
+                    ></app-svg>
+                  }
+                  @if (environment.proxyMode) {
+                    <app-svg
+                      class="text-primary me-2"
+                      icon="security"
+                      size="12"
+                      ngbTooltip="Proxy mode enabled"
+                    ></app-svg>
+                  }
+                  @if ((logsRecording$ | async)[environment.uuid] === true) {
+                    <app-svg
+                      class="text-danger animation-flash me-2"
+                      icon="record"
+                      size="12"
+                      ngbTooltip="Recording in progress"
+                    ></app-svg>
+                  }
+                  @let localUrl =
+                    instanceUrls[environment.uuid].localUrl +
+                    (environment?.endpointPrefix
+                      ? '/' + environment?.endpointPrefix
+                      : '');
+                  <span
+                    class="text-truncate pe-1"
+                    (click)="
+                      copyUrlToClipboard(
+                        environment,
+                        instances[environment.uuid],
+                        'localUrl'
+                      )
+                    "
+                    ngbTooltip="Click to copy"
+                  >
+                    {{ localUrl }}
+                  </span>
+                </div>
+
+                <!-- Display remote instance URL and status on desktop -->
+                @if (instances[environment.uuid]) {
+                  <div
+                    class="nav-link-subtitle mt-1 d-flex align-items-center svg-text-align"
+                  >
+                    <app-svg
+                      class="me-2"
+                      [ngClass]="{
+                        'text-success':
+                          instances[environment.uuid]?.status === 'RUNNING',
+                        'text-muted':
+                          instances[environment.uuid]?.status !== 'RUNNING'
+                      }"
+                      icon="cloud"
+                      size="12"
+                      [ngbTooltip]="
+                        instances[environment.uuid]?.status === 'RUNNING'
+                          ? 'Cloud instance running'
+                          : 'Cloud instance stopped'
+                      "
+                    ></app-svg>
+
+                    @let webUrl =
+                      instanceUrls[environment.uuid].webUrl +
+                      (environment?.endpointPrefix
+                        ? '/' + environment?.endpointPrefix
+                        : '');
+                    <span
+                      class="text-truncate pe-1"
+                      (click)="
+                        copyUrlToClipboard(
+                          environment,
+                          instances[environment.uuid],
+                          'webUrl'
+                        )
+                      "
+                      ngbTooltip="Click to copy"
+                    >
+                      {{ webUrl }}
+                    </span>
+                  </div>
                 }
-              </div>
+              }
             </div>
             <div
               class="ms-auto d-flex flex-column align-items-center justify-content-between"

--- a/packages/app/src/renderer/app/components/menus/environments-menu/environments-menu.component.ts
+++ b/packages/app/src/renderer/app/components/menus/environments-menu/environments-menu.component.ts
@@ -12,7 +12,12 @@ import {
   UntypedFormControl,
   UntypedFormGroup
 } from '@angular/forms';
-import { Plans, SyncDisconnectReasons, SyncErrors } from '@mockoon/cloud';
+import {
+  DeployInstance,
+  Plans,
+  SyncDisconnectReasons,
+  SyncErrors
+} from '@mockoon/cloud';
 import {
   Environment,
   Environments,
@@ -95,7 +100,9 @@ export class EnvironmentsMenuComponent implements OnInit, OnDestroy {
   public activeEnvironment$: Observable<Environment>;
   public environments$: Observable<Environments>;
   public cloudEnvironments$: Observable<Environments>;
-  public instanceUrls$: Observable<Record<string, string[]>>;
+  public instanceUrls$: Observable<
+    Record<string, { webUrl: string; localUrl: string }>
+  >;
   public environmentsStatus$: Observable<EnvironmentsStatuses>;
   public settings$: Observable<Settings>;
   public menuSize = Config.defaultMainMenuSize;
@@ -114,6 +121,7 @@ export class EnvironmentsMenuComponent implements OnInit, OnDestroy {
   public offlineWarningLink = Config.docs.cloudSyncOffline;
   public isWeb = Config.isWeb;
   public deployInstances$ = this.store.select('deployInstances');
+  public buildApiUrl = buildApiUrl;
   public alertLabels = {
     VERSION_TOO_OLD_WARNING:
       'We will soon not support your Mockoon version anymore. Please update.',
@@ -480,7 +488,10 @@ export class EnvironmentsMenuComponent implements OnInit, OnDestroy {
               deployInstance.environmentUuid === environment.uuid
           );
 
-          instanceUrls[environment.uuid] = buildApiUrl(environment, instance);
+          instanceUrls[environment.uuid] = buildApiUrl({
+            environment,
+            instance
+          });
 
           return instanceUrls;
         }, {});
@@ -564,6 +575,21 @@ export class EnvironmentsMenuComponent implements OnInit, OnDestroy {
 
   public addCloudEnvironment() {
     this.environmentsService.addCloudEnvironment(null, true).subscribe();
+  }
+
+  public copyUrlToClipboard(
+    environment: Environment,
+    instance: DeployInstance,
+    urlName: 'webUrl' | 'localUrl'
+  ) {
+    const urls = buildApiUrl({
+      environment,
+      instance,
+      includeProtocol: true,
+      includePrefix: true
+    });
+
+    navigator.clipboard.writeText(urls[urlName]);
   }
 
   /**

--- a/packages/app/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.ts
+++ b/packages/app/src/renderer/app/components/modals/deploy-instance-modal/deploy-instance-modal.component.ts
@@ -62,6 +62,7 @@ export class DeployInstanceModalComponent implements OnInit {
   public instanceExists$: Observable<boolean>;
   public user$: Observable<User>;
   public accountUrl = Config.accountUrl;
+  public isWeb = Config.isWeb;
   public optionsForm = this.formBuilder.group({
     subdomain: this.formBuilder.control<string>(null, {
       validators: [
@@ -209,9 +210,16 @@ export class DeployInstanceModalComponent implements OnInit {
           this.taskInProgress$.next(false);
 
           if (newInstance) {
-            this.store.update(
-              updateEnvironmentStatusAction({ running: true }, environmentUuid)
-            );
+            // only update the main running state if on the web app
+            if (this.isWeb) {
+              this.store.update(
+                updateEnvironmentStatusAction(
+                  { running: true },
+                  environmentUuid
+                )
+              );
+            }
+
             this.uiService.closeModal('deploy', false);
             this.uiService.openModal('manageInstances', {
               environmentUuid,

--- a/packages/app/src/renderer/app/services/deploy.service.ts
+++ b/packages/app/src/renderer/app/services/deploy.service.ts
@@ -28,6 +28,8 @@ import { Config } from 'src/renderer/config';
 
 @Injectable({ providedIn: 'root' })
 export class DeployService {
+  public isWeb = Config.isWeb;
+
   constructor(
     private userService: UserService,
     private store: Store,
@@ -187,9 +189,12 @@ export class DeployService {
    * @returns
    */
   public quickRedeploy(environmentUuid: string): Observable<DeployInstance> {
-    this.store.update(
-      updateEnvironmentStatusAction({ redeploying: true }, environmentUuid)
-    );
+    if (this.isWeb) {
+      this.store.update(
+        updateEnvironmentStatusAction({ redeploying: true }, environmentUuid)
+      );
+    }
+
     const instances = this.store.get('deployInstances');
     const existingInstance = instances.find(
       (instance) => instance.environmentUuid === environmentUuid

--- a/packages/app/src/renderer/app/stores/reducer.ts
+++ b/packages/app/src/renderer/app/stores/reducer.ts
@@ -42,6 +42,7 @@ import {
   updateDuplicatedRoutes,
   updateEditorAutocomplete
 } from 'src/renderer/app/stores/reducer-utils';
+import { Config } from 'src/renderer/config';
 import { EnvironmentDescriptor } from 'src/shared/models/settings.model';
 
 export type ReducerDirectionType = 'next' | 'previous';
@@ -96,21 +97,24 @@ export const environmentReducer = (
       newState = {
         ...state,
         deployInstances: [...action.instances],
-        environmentsStatus: {
-          ...state.environmentsStatus,
-          ...action.instances.reduce<EnvironmentsStatuses>(
-            (instances, instance) => {
-              instances[instance.environmentUuid] = {
-                running: true,
-                needRestart: false,
-                redeploying: false
-              };
+        // only update the env status on desktop
+        environmentsStatus: Config.isWeb
+          ? {
+              ...state.environmentsStatus,
+              ...action.instances.reduce<EnvironmentsStatuses>(
+                (instances, instance) => {
+                  instances[instance.environmentUuid] = {
+                    running: true,
+                    needRestart: false,
+                    redeploying: false
+                  };
 
-              return instances;
-            },
-            {}
-          )
-        }
+                  return instances;
+                },
+                {}
+              )
+            }
+          : state.environmentsStatus
       };
       break;
     }
@@ -119,14 +123,17 @@ export const environmentReducer = (
       newState = {
         ...state,
         deployInstances: [action.instance, ...state.deployInstances],
-        environmentsStatus: {
-          ...state.environmentsStatus,
-          [action.instance.environmentUuid]: {
-            running: true,
-            needRestart: false,
-            redeploying: false
-          }
-        }
+        // only update the env status on desktop
+        environmentsStatus: Config.isWeb
+          ? {
+              ...state.environmentsStatus,
+              [action.instance.environmentUuid]: {
+                running: true,
+                needRestart: false,
+                redeploying: false
+              }
+            }
+          : state.environmentsStatus
       };
       break;
     }
@@ -143,14 +150,17 @@ export const environmentReducer = (
       newState = {
         ...state,
         deployInstances: newDeployInstances,
-        environmentsStatus: {
-          ...state.environmentsStatus,
-          [action.environmentUuid]: {
-            running: true,
-            needRestart: false,
-            redeploying: false
-          }
-        }
+        // only update the env status on desktop
+        environmentsStatus: Config.isWeb
+          ? {
+              ...state.environmentsStatus,
+              [action.environmentUuid]: {
+                running: true,
+                needRestart: false,
+                redeploying: false
+              }
+            }
+          : state.environmentsStatus
       };
       break;
     }
@@ -161,14 +171,17 @@ export const environmentReducer = (
         deployInstances: state.deployInstances.filter(
           (instance) => instance.environmentUuid !== action.environmentUuid
         ),
-        environmentsStatus: {
-          ...state.environmentsStatus,
-          [action.environmentUuid]: {
-            running: false,
-            needRestart: false,
-            redeploying: false
-          }
-        }
+        // only update the env status on desktop
+        environmentsStatus: Config.isWeb
+          ? {
+              ...state.environmentsStatus,
+              [action.environmentUuid]: {
+                running: false,
+                needRestart: false,
+                redeploying: false
+              }
+            }
+          : state.environmentsStatus
       };
       break;
     }

--- a/packages/app/src/renderer/styles/boostrap-overrides.scss
+++ b/packages/app/src/renderer/styles/boostrap-overrides.scss
@@ -52,22 +52,6 @@
       inset -2px 0 0 0 $red,
       inset 2px 0 0 0 $blue;
   }
-  .nav-link.running {
-    box-shadow: inset -3px 0 0 0 $green;
-  }
-  .nav-link.active.running {
-    box-shadow:
-      inset 2px 0 0 0 $blue,
-      inset -3px 0 0 0 $green;
-  }
-  .nav-link.need-restart {
-    box-shadow: inset -3px 0 0 0 $orange;
-  }
-  .nav-link.active.need-restart {
-    box-shadow:
-      inset 2px 0 0 0 $blue,
-      inset -3px 0 0 0 $orange;
-  }
 }
 
 .form-label::after {

--- a/packages/app/test/libs/environments.ts
+++ b/packages/app/test/libs/environments.ts
@@ -28,7 +28,7 @@ class Environments {
 
   private get runningEnvironmentMenuEntry() {
     return $(
-      '.environments-menu .menu-list .nav-item .nav-link.active.running'
+      '.environments-menu .menu-list .nav-item .nav-link.active .nav-link-subtitle app-svg[icon="computer"].text-success'
     );
   }
 
@@ -172,14 +172,12 @@ class Environments {
 
   public async assertNeedsRestart() {
     await $(
-      '.environments-menu .menu-list .nav-item .nav-link.active.need-restart'
+      '.environments-menu .menu-list .nav-item .nav-link.active .nav-link-subtitle app-svg[icon="computer"].text-orange'
     ).waitForExist();
   }
 
   public async assertStarted() {
-    await $(
-      '.environments-menu .menu-list .nav-item .nav-link.active.running'
-    ).waitForExist();
+    await this.runningEnvironmentMenuEntry.waitForExist();
   }
 }
 


### PR DESCRIPTION
- Do not use the environment status to display a cloud instance status (but only for the desktop version).
- Update the header's play button behavior on desktop to only react to the local server status and correctly stop the local server instead of the cloud one.
- Display both local and cloud URLs when deployed in the main environment menu with status indicators.
- For better consistency, remove the right inner shadow green indicator (environment menu item) and replace by icons indicators for both local and remote (see above). Closes #1738

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
