### PR TITLE
Add support for JMESPath

### DIFF
--- a/packages/commons-server/package-lock.json
+++ b/packages/commons-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.1",
         "@faker-js/faker": "9.6.0",
+        "@jmespath-community/jmespath": "1.1.5",
         "@mockoon/commons": "9.2.0",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
@@ -145,6 +146,14 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@jmespath-community/jmespath": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@jmespath-community/jmespath/-/jmespath-1.1.5.tgz",
+      "integrity": "sha512-N4iBwuej3QBiUXgYtA2dlwnbgr6NU9cjRukV4UkWo4gW/FQKHZ9gRlsoXAfEYFzblp8ZPfyzlY6KdsdpkBgyaQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jsdevtools/ono": {

--- a/packages/commons-server/package.json
+++ b/packages/commons-server/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "10.1.1",
     "@faker-js/faker": "9.6.0",
+    "@jmespath-community/jmespath": "1.1.5",
     "@mockoon/commons": "9.2.0",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",

--- a/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/data-helpers.ts
@@ -111,9 +111,12 @@ export const DataHelpers = function (
         return;
       }
 
-      const path = convertPathToArray(
+      let path: string[] | null = convertPathToArray(
         String(fromSafeString(parameters[2]) ?? '')
       );
+
+      path = path.length > 0 ? path : null;
+
       // new value can be of any type
       const newValue = fromSafeString(parameters[3]);
 

--- a/packages/commons-server/src/libs/templating-helpers/helpers/index.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/index.ts
@@ -48,8 +48,10 @@ import int from './int';
 import ipv4 from './ipv4';
 import ipv6 from './ipv6';
 import isValidDate from './isValidDate';
+import jmesPath from './jmes-path';
 import join from './join';
 import jsonParse from './json-parse';
+import jsonPath from './json-path';
 import { jwtHeader, jwtPayload } from './jwt';
 import lastName from './lastName';
 import lat from './lat';
@@ -64,6 +66,7 @@ import multiply from './multiply';
 import newline from './newline';
 import now from './now';
 import object from './object';
+import objectPath from './object-path';
 import objectId from './objectId';
 import objectMerge from './objectMerge';
 import oneOf from './oneOf';
@@ -134,8 +137,10 @@ export const Helpers = {
   int,
   ipv4,
   ipv6,
+  jmesPath,
   join,
   jsonParse,
+  jsonPath,
   jwtHeader,
   jwtPayload,
   lastName,
@@ -153,6 +158,7 @@ export const Helpers = {
   object,
   objectId,
   objectMerge,
+  objectPath,
   oneOf,
   padEnd,
   padStart,

--- a/packages/commons-server/src/libs/templating-helpers/helpers/jmes-path.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/jmes-path.ts
@@ -1,0 +1,19 @@
+import { fromSafeString, getValueFromPath } from '../../utils';
+
+const jmesPath = function (...args: any[]) {
+  // remove last item (handlebars options argument)
+  const parameters = args.slice(0, -1);
+
+  // we need at least some data and a path
+  if (parameters.length < 2) {
+    return;
+  }
+
+  const data = fromSafeString(parameters[0]);
+  const path = fromSafeString(parameters[1]);
+  const defaultValue = parameters[2] ?? '';
+
+  return getValueFromPath.jmesPath(data, path, defaultValue);
+};
+
+export default jmesPath;

--- a/packages/commons-server/src/libs/templating-helpers/helpers/json-path.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/json-path.ts
@@ -1,0 +1,19 @@
+import { fromSafeString, getValueFromPath } from '../../utils';
+
+const jsonPath = function (...args: any[]) {
+  // remove last item (handlebars options argument)
+  const parameters = args.slice(0, -1);
+
+  // we need at least some data and a path
+  if (parameters.length < 2) {
+    return;
+  }
+
+  const data = fromSafeString(parameters[0]);
+  const path = fromSafeString(parameters[1]);
+  const defaultValue = parameters[2] ?? '';
+
+  return getValueFromPath.jsonPath(data, path, defaultValue);
+};
+
+export default jsonPath;

--- a/packages/commons-server/src/libs/templating-helpers/helpers/object-path.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/object-path.ts
@@ -1,0 +1,19 @@
+import { fromSafeString, getValueFromPath } from '../../utils';
+
+const objectPath = function (...args: any[]) {
+  // remove last item (handlebars options argument)
+  const parameters = args.slice(0, -1);
+
+  // we need at least some data and a path
+  if (parameters.length < 2) {
+    return;
+  }
+
+  const data = fromSafeString(parameters[0]);
+  const path = fromSafeString(parameters[1]);
+  const defaultValue = parameters[2] ?? '';
+
+  return getValueFromPath.objectPath(data, path, defaultValue);
+};
+
+export default objectPath;

--- a/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
+++ b/packages/commons-server/test/specs/response-rules/response-rules-interpreter.test.ts
@@ -3553,7 +3553,7 @@ describe('Response rules interpreter', () => {
       strictEqual(routeResponse?.body, 'body19');
     });
 
-    it('should return response if JSON body property value is null nad rule value is null too', () => {
+    it('should return response if JSON body property value is null and rule value is null too', () => {
       const request: Request = {
         header: function (headerName: string) {
           const headers = {

--- a/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
+++ b/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
@@ -3509,4 +3509,229 @@ describe('Helper: jwt', () => {
       strictEqual(parseResult, 'HS256');
     });
   });
+
+  describe('objectPath', () => {
+    it('should return nothing if data param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ objectPath }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return nothing if path param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ objectPath (bodyRaw)}}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: { body: {} } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return default value if data is empty', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ objectPath (bodyRaw) "prop2.data" "hello" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123'
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'hello');
+    });
+
+    it('should return value when found', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ objectPath (bodyRaw) "prop2.data" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123',
+            prop2: {
+              data: 'super'
+            }
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'super');
+    });
+  });
+
+  describe('jsonPath', () => {
+    it('should return nothing if data param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jsonPath }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return nothing if path param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jsonPath (bodyRaw)}}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: { body: {} } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return default value if data is empty', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jsonPath (bodyRaw) "$.prop2.data" "hello" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123'
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'hello');
+    });
+
+    it('should return value when found', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jsonPath (bodyRaw) "$.prop2.data" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123',
+            prop2: {
+              data: 'super'
+            }
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'super');
+    });
+  });
+
+  describe('jmesPath', () => {
+    it('should return nothing if data param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jmesPath }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return nothing if path param is missing', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jmesPath (bodyRaw)}}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: { body: {} } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, '');
+    });
+
+    it('should return default value if data is empty', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jmesPath (bodyRaw) "prop2.data" "hello" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123'
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'hello');
+    });
+
+    it('should return value when found', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jmesPath (bodyRaw) "prop2.data" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            prop1: '123',
+            prop2: {
+              data: 'super'
+            }
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'super');
+    });
+
+    it('should return value with more complex path', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{ jmesPath (bodyRaw) "arr[1:3]" }}',
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          body: {
+            arr: ['a', 'b', 'c', 'd']
+          }
+        } as any,
+        envVarsPrefix: ''
+      });
+
+      strictEqual(parseResult, 'b,c');
+    });
+  });
 });


### PR DESCRIPTION
JMESPath replaces object-path where it both JSONPath and object-path were supported. A conversion on object-path syntaxes is made to ensure compatibility with JMESPath

Closes #1731

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
