### PR TITLE
Add a validate command for the CLI

### DIFF
--- a/packages/app/test/specs/schema-validation.spec.ts
+++ b/packages/app/test/specs/schema-validation.spec.ts
@@ -132,10 +132,15 @@ describe('Schema validation', () => {
         'body'
       );
 
-      // strip invalid array item
-      expect(fileContent.routes[0].responses[0].headers).toHaveLength(1);
-      expect(fileContent.routes[0].responses[0].headers[0].key).toEqual(
+      // rebuild invalid array item
+      expect(fileContent.routes[0].responses[0].headers).toHaveLength(2);
+      expect(fileContent.routes[0].responses[0].headers[0].key).toEqual('');
+      expect(fileContent.routes[0].responses[0].headers[0].value).toEqual('');
+      expect(fileContent.routes[0].responses[0].headers[1].key).toEqual(
         'Content-Type'
+      );
+      expect(fileContent.routes[0].responses[0].headers[1].value).toEqual(
+        'application/json'
       );
 
       await environments.close(1);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,13 +103,14 @@ Mockoon's CLI has been tested on Node.js versions 18 and 20.
 
 ## Commands
 
-- [Start command](#start-command)
-- [Dockerize command](#dockerize-command)
-- [Import command](#import-command)
-- [Export command](#export-command)
-- [Help command](#help-command)
+- [`start`](#start-command)
+- [`dockerize`](#dockerize-command)
+- [`import`](#import-command)
+- [`export`](#export-command)
+- [`validate`](#validate-command)
+- [`help`](#help-command)
 
-### Start command
+### `start` command
 
 Starts one (or more) mock API from Mockoon's environment file(s) as a foreground process.
 
@@ -180,7 +181,7 @@ For example, to disable all routes in a folder named `folder1`, and all routes h
 
 To disable all routes, use `--disable-routes=*` or `--disable-routes "*"`.
 
-### Dockerize command
+### `dockerize` command
 
 Generates a Dockerfile used to build a self-contained image of one or more mock API. After building the image, no additional parameters will be needed when running the container.
 This command takes similar flags as the [`start` command](#mockoon-start).
@@ -210,7 +211,7 @@ $ mockoon-cli dockerize --data ~/data1.json ~/data2.json --output ./Dockerfile
 $ mockoon-cli dockerize --data https://file-server/data.json --output ./Dockerfile
 ```
 
-### Import command
+### `import` command
 
 Import a Swagger v2/OpenAPI v3 specification file (YAML or JSON).
 
@@ -237,7 +238,7 @@ $ mockoon-cli import --input ~/input.yaml --output ./output.json
 $ mockoon-cli import --input ~/input.json --output ./output.json --prettify
 ```
 
-### Export command
+### `export` command
 
 Export a mock API to an OpenAPI v3 specification file (JSON).
 
@@ -261,7 +262,39 @@ $ mockoon-cli export --input ~/input.json --output ./output.json
 $ mockoon-cli export --input ~/input.json --output ./output.json --prettify
 ```
 
-### Help command
+### `validate` command
+
+Validate a Mockoon [environment JSON file](https://mockoon.com/docs/latest/mockoon-data-files/data-files-location/#data-files-schema) against the schema:
+
+```sh-session
+$ mockoon-cli validate --data ~/data1.json ~/data2.json
+$ mockoon-cli validate --data https://file-server/data.json
+```
+
+> 💡 The `--data` flag behaves like the `--data` flag in the `start` command, meaning you can provide multiple paths or URLs to validate multiple files at once.
+
+If the files are valid, you will see:
+
+```
+✓ Valid environment: ~/data1.json
+✓ Valid environment: ~/data2.json
+✓ All environments are valid
+```
+
+If one or more files are invalid, you will see validation errors:
+
+```
+Invalid environment: ~/data1.json
+- "name" is required
+- "port" must be a number
+Invalid environment: ~/data2.json
+- "routes" must be an array
+ »   Error: Environments validation failed
+```
+
+> ⚠️ This command does not validate the OpenAPI specification files. OpenAPI files are validated by the [start command](#start-command) when you run it with an OpenAPI file as the `--data` parameter.
+
+### `help` command
 
 Returns information about a command.
 

--- a/packages/cli/src/commands/dockerize.ts
+++ b/packages/cli/src/commands/dockerize.ts
@@ -5,7 +5,10 @@ import { render as mustacheRender } from 'mustache';
 import { ParsedPath, parse as pathParse, resolve as pathResolve } from 'path';
 import { Config } from '../config';
 import { CLIMessages } from '../constants/cli-messages.constants';
-import { commonFlags } from '../constants/command.constants';
+import {
+  commonFlags,
+  logTransactionFlag
+} from '../constants/command.constants';
 import { DOCKER_TEMPLATE } from '../constants/docker.constants';
 
 export default class Dockerize extends Command {
@@ -20,6 +23,7 @@ export default class Dockerize extends Command {
 
   public static flags = {
     ...commonFlags,
+    ...logTransactionFlag,
     port: Flags.integer({
       char: 'p',
       description:

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -17,7 +17,10 @@ import { Command, Flags } from '@oclif/core';
 import { join } from 'path';
 import { format } from 'util';
 import { Config } from '../config';
-import { commonFlags } from '../constants/command.constants';
+import {
+  commonFlags,
+  logTransactionFlag
+} from '../constants/command.constants';
 import { parseDataFiles } from '../libs/data';
 import { getDirname, transformEnvironmentName } from '../libs/utils';
 
@@ -35,6 +38,7 @@ export default class Start extends Command {
 
   public static flags = {
     ...commonFlags,
+    ...logTransactionFlag,
     hostname: Flags.string({
       char: 'l',
       description: 'Listening hostname(s)',

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,76 @@
+import { EnvironmentSchemaNoFix } from '@mockoon/commons';
+import { Command } from '@oclif/core';
+import { commonFlags } from '../constants/command.constants';
+import { loadFile } from '../libs/data';
+import { terminalColors } from '../libs/utils';
+
+export default class Validate extends Command {
+  public static description = 'Validate a Mockoon environment JSON file';
+
+  public static examples = [
+    '$ mockoon-cli validate --data ~/data1.json ~/data2.json',
+    '$ mockoon-cli validate --data https://file-server/data.json'
+  ];
+
+  public static flags = {
+    ...commonFlags
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(Validate);
+
+    try {
+      const parsedEnvironments: {
+        originalPath: string;
+        environment: string;
+      }[] = [];
+      for (const [_index, filePath] of flags.data.entries()) {
+        parsedEnvironments.push({
+          originalPath: filePath,
+          environment: await loadFile(filePath)
+        });
+      }
+
+      let hasErrors = false;
+
+      for (const envInfo of parsedEnvironments) {
+        const { error } = EnvironmentSchemaNoFix.validate(envInfo.environment, {
+          abortEarly: false,
+          debug: true
+        });
+
+        if (error) {
+          this.log(
+            `${terminalColors.red}⨯${terminalColors.reset} Invalid environment: ${envInfo.originalPath}`
+          );
+
+          error.details.forEach((detail) => {
+            this.log(
+              `  ${terminalColors.red}⨯${terminalColors.reset} ${detail.message}`
+            );
+          });
+
+          hasErrors = true;
+        } else {
+          this.log(
+            `${terminalColors.green}✓${terminalColors.reset} Valid environment: ${envInfo.originalPath}`
+          );
+        }
+      }
+
+      if (hasErrors) {
+        this.error('Environments validation failed', {
+          exit: 1
+        });
+      } else {
+        this.log(
+          `${terminalColors.green}✓${terminalColors.reset} All environments are valid`
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        this.error(error.message);
+      }
+    }
+  }
+}

--- a/packages/cli/src/constants/command.constants.ts
+++ b/packages/cli/src/constants/command.constants.ts
@@ -2,15 +2,18 @@ import { Flags } from '@oclif/core';
 
 export const commonFlags = {
   help: Flags.help({ char: 'h' }),
-  'log-transaction': Flags.boolean({
-    char: 't',
-    description: 'Log the full HTTP transaction (request and response)',
-    default: false
-  }),
   data: Flags.string({
     char: 'd',
     description: 'Path(s) or URL(s) to your Mockoon data file(s)',
     required: true,
     multiple: true
+  })
+};
+
+export const logTransactionFlag = {
+  'log-transaction': Flags.boolean({
+    char: 't',
+    description: 'Log the full HTTP transaction (request and response)',
+    default: false
   })
 };

--- a/packages/cli/src/libs/data.ts
+++ b/packages/cli/src/libs/data.ts
@@ -62,6 +62,33 @@ const migrateAndValidateEnvironment = async (
 };
 
 /**
+ * Load a file from the filesystem or a URL.
+ * If the file is a JSON file, it will be parsed.
+ *
+ * @param filePath
+ * @returns
+ */
+export const loadFile = async (filePath: string): Promise<string> => {
+  try {
+    let data: any;
+
+    if (filePath.startsWith('http')) {
+      data = await (await fetch(filePath)).text();
+    } else {
+      data = await fs.readFile(filePath, { encoding: 'utf-8' });
+    }
+
+    if (typeof data === 'string') {
+      data = JSON.parse(data);
+    }
+
+    return data;
+  } catch (error: unknown) {
+    throw new Error((error as Error).message);
+  }
+};
+
+/**
  * Load and parse one or more JSON data file(s).
  *
  * @param filePaths
@@ -95,17 +122,7 @@ export const parseDataFiles = async (
       }
 
       try {
-        let data: any;
-
-        if (filePath.startsWith('http')) {
-          data = await (await fetch(filePath)).text();
-        } else {
-          data = await fs.readFile(filePath, { encoding: 'utf-8' });
-        }
-
-        if (typeof data === 'string') {
-          data = JSON.parse(data);
-        }
+        const data = await loadFile(filePath);
 
         if (typeof data === 'object') {
           environment = await migrateAndValidateEnvironment(data, repair);

--- a/packages/cli/src/libs/utils.ts
+++ b/packages/cli/src/libs/utils.ts
@@ -24,3 +24,9 @@ export const getDirname = (path: string): string | null => {
 
   return null;
 };
+
+export const terminalColors = {
+  reset: '\x1b[39m',
+  red: '\x1b[31m',
+  green: '\x1b[32m'
+};

--- a/packages/cli/test/specs/validate-command.test.ts
+++ b/packages/cli/test/specs/validate-command.test.ts
@@ -1,0 +1,57 @@
+import { ok } from 'node:assert';
+import { mkdir, rm } from 'node:fs/promises';
+import { after, before, describe, it } from 'node:test';
+import { spawnCli } from '../libs/helpers';
+
+describe('Validate command', () => {
+  before(async () => {
+    await mkdir('./tmp', { recursive: true });
+  });
+
+  after(async () => {
+    await rm('./tmp', { recursive: true });
+  });
+
+  it('should validate valid and invalid envs', async () => {
+    const { output } = await spawnCli([
+      'validate',
+      '--data',
+      './test/data/envs/repair.json',
+      './test/data/envs/mock1.json'
+    ]);
+
+    const { stdout, stderr } = await output;
+
+    ok(stdout.includes('Invalid environment: ./test/data/envs/repair.json'));
+    ok(stdout.includes('"lastMigration" is required'));
+    ok(stdout.includes('"rootChildren" is required'));
+    ok(stdout.includes('"folders" is required'));
+    ok(stdout.includes('"routes[0].type" is required'));
+    ok(stdout.includes('"routes[0].method" is required'));
+    ok(stdout.includes('"routes[0].responses[0].bodyType" is required'));
+    ok(stdout.includes('"routes[0].responses[0].databucketID" is required'));
+    ok(stdout.includes('"routes[0].responses[0].default" is required'));
+    ok(stdout.includes('"routes[0].responses[0].crudKey" is required'));
+    ok(stdout.includes('"routes[0].responses[0].callbacks" is required'));
+    ok(stdout.includes('"routes[0].responseMode" is required'));
+    ok(stdout.includes('"routes[0].streamingMode" is required'));
+    ok(stdout.includes('"routes[0].streamingInterval" is required'));
+    ok(stdout.includes('"data" is required'));
+    ok(stdout.includes('"callbacks" is required'));
+    ok(stdout.includes('Valid environment'));
+    ok(stderr.includes('Error: Environments validation failed'));
+  });
+
+  it('should validate valid envs', async () => {
+    const { output } = await spawnCli([
+      'validate',
+      '--data',
+      './test/data/envs/mock1.json',
+      './test/data/envs/mock2.json'
+    ]);
+
+    const { stdout } = await output;
+    ok(stdout.includes('Valid environment'));
+    ok(stdout.includes('All environments are valid'));
+  });
+});


### PR DESCRIPTION
Validates Mockoon environment's data files.
Creates a new way to build the environment schema: auto repairing with defaults and failovers, and non-repairing to allow validation. Closes #1754

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [x] CLI tests added (@mockoon/cli)
- [x] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
