### PR TITLE
Fix launch error on Ubuntu

### DIFF
--- a/packages/app/build-configs/electron-builder.linux.js
+++ b/packages/app/build-configs/electron-builder.linux.js
@@ -6,6 +6,7 @@ const commonConfig = require('./electron-builder.common');
  */
 const config = Object.assign({}, commonConfig, {
   linux: {
+    executableName: 'mockoon',
     target: [
       {
         target: 'AppImage',

--- a/packages/app/build-configs/test/electron-builder.linux.js
+++ b/packages/app/build-configs/test/electron-builder.linux.js
@@ -6,6 +6,7 @@ const commonConfig = require('../electron-builder.common');
  */
 const config = Object.assign({}, commonConfig, {
   linux: {
+    executableName: 'mockoon',
     target: [
       {
         target: 'AppImage'


### PR DESCRIPTION
Something recently changed in electron-builder that changed the executable name and used "Mockoon" with a capital M (it reverted to use the productName).

Closes #1796

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
