### PR TITLE
Make cloud logs replayable upon (re) connection

### DIFF
--- a/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.html
+++ b/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.html
@@ -42,7 +42,9 @@
           data.clearEnvironmentLogsRequested?.enabled ? 'text-danger' : ''
         }}"
         [ngbTooltip]="
-          data.clearEnvironmentLogsRequested?.enabled ? 'Confirm' : 'Clear logs'
+          data.clearEnvironmentLogsRequested?.enabled
+            ? 'Confirm'
+            : 'Clear logs view'
         "
         (click)="clearEnvironmentLogs()"
         [disabled]="data.environmentLogsCount === 0"

--- a/packages/app/src/renderer/app/components/modals/settings-modal/settings-modal.component.html
+++ b/packages/app/src/renderer/app/components/modals/settings-modal/settings-modal.component.html
@@ -116,7 +116,11 @@
           type="number"
           class="form-control col-1"
           id="settings-log-max-count"
-          [appInputNumber]="{ min: 1, max: Infinity, canBeEmpty: false }"
+          [appInputNumber]="{
+            min: 1,
+            max: maxLogsPerEnvironmentLimit,
+            canBeEmpty: false
+          }"
           formControlName="maxLogsPerEnvironment"
         />
       </div>

--- a/packages/app/src/renderer/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/packages/app/src/renderer/app/components/modals/settings-modal/settings-modal.component.ts
@@ -51,6 +51,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   ];
   public settingsForm: UntypedFormGroup;
   public isWeb = Config.isWeb;
+  public maxLogsPerEnvironmentLimit = Config.maxLogsPerEnvironmentLimit;
   private destroy$ = new Subject<void>();
 
   constructor(

--- a/packages/app/src/renderer/app/constants/settings-schema.constants.ts
+++ b/packages/app/src/renderer/app/constants/settings-schema.constants.ts
@@ -44,6 +44,7 @@ export const SettingsSchema = Joi.object<Settings, true>({
   welcomeShown: Joi.boolean().failover(SettingsDefault.welcomeShown).required(),
   maxLogsPerEnvironment: Joi.number()
     .min(1)
+    .max(Config.maxLogsPerEnvironmentLimit)
     .failover(SettingsDefault.maxLogsPerEnvironment)
     .required(),
   truncateRouteName: Joi.boolean()

--- a/packages/app/src/renderer/app/stores/reducer.ts
+++ b/packages/app/src/renderer/app/stores/reducer.ts
@@ -1359,6 +1359,15 @@ export const environmentReducer = (
     }
 
     case ActionTypes.LOG_REQUEST: {
+      // do not process if the timestamp is already in the logs
+      if (
+        state.environmentsLogs[action.environmentUUID]?.some(
+          (log) => log.timestampMs === action.logItem.timestampMs
+        )
+      ) {
+        return state;
+      }
+
       const newEnvironmentsLogs = { ...state.environmentsLogs };
 
       newEnvironmentsLogs[action.environmentUUID] = [

--- a/packages/app/src/shared/shared-config.ts
+++ b/packages/app/src/shared/shared-config.ts
@@ -54,6 +54,7 @@ export const SharedConfig = (options: {
     cloudPlansURL: `${options.websiteURL}cloud/`,
     maxPromptLength: 500,
     defaultMaxLogsPerEnvironment: defaultMaxTransactionLogs,
+    maxLogsPerEnvironmentLimit: 1_000,
     defaultMainMenuSize: 100,
     defaultSecondaryMenuSize: 200,
     storageSaveDelay: 1000, // ms

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -551,10 +551,12 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     next: NextFunction
   ) => {
     response.on('close', () => {
-      this.emit('transaction-complete', CreateTransaction(request, response));
+      const transaction = CreateTransaction(request, response);
+
+      this.emit('transaction-complete', transaction);
 
       // store the transaction logs at beginning of the array
-      this.transactionLogs.unshift(CreateTransaction(request, response));
+      this.transactionLogs.unshift(transaction);
 
       // keep only the last n transactions
       if (this.transactionLogs.length > this.options.maxTransactionLogs) {


### PR DESCRIPTION
- Move message queue logic outside of SSE class
- Limit max displayed logs to 1000
- fetch max logs from SSE /events endpoint upon connection Closes #1807

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #1807 
