### PR TITLE
Add convert local to cloud command palette entry

### DIFF
--- a/packages/app/src/renderer/app/services/command-palette.service.ts
+++ b/packages/app/src/renderer/app/services/command-palette.service.ts
@@ -287,6 +287,7 @@ export class CommandPaletteService {
     const hasAtLeastOneEnvironment = this.store.get('environments').length > 0;
     const hasMoreThanOneEnvironment = this.store.get('environments').length > 1;
     const hasActiveEnvironment = !!this.store.getActiveEnvironment();
+    const activeEnvironmentIsLocal = this.store.getIsActiveEnvLocal();
     const hasActiveRoute = !!this.store.getActiveRoute();
     const activeEnvironment = this.store.getActiveEnvironment();
     const activeEnvironmentUuid = activeEnvironment?.uuid;
@@ -744,9 +745,10 @@ export class CommandPaletteService {
       }
     ];
 
+    // desktop only commands (zoom, local env management, etc.)
     if (!Config.isWeb) {
       commonCommands.push(
-        // zoom cannot be controled in the browser
+        // zoom cannot be controlled in the browser
         {
           id: 'VIEW_ZOOM_IN',
           label: 'Zoom in',
@@ -757,7 +759,7 @@ export class CommandPaletteService {
           score: 1,
           enabled: true
         },
-        // zoom cannot be controled in the browser
+        // zoom cannot be controlled in the browser
         {
           id: 'VIEW_ZOOM_OUT',
           label: 'Zoom out',
@@ -768,7 +770,7 @@ export class CommandPaletteService {
           score: 1,
           enabled: true
         },
-        // zoom cannot be controled in the browser
+        // zoom cannot be controlled in the browser
         {
           id: 'VIEW_ZOOM_RESET',
           label: 'Reset zoom',
@@ -906,6 +908,17 @@ export class CommandPaletteService {
           },
           score: 1,
           enabled: true
+        },
+        {
+          id: 'CONVERT_ENVIRONMENT_TO_CLOUD',
+          label: 'Convert Current Local Environment to Cloud',
+          action: () => {
+            this.environmentsService
+              .convertCurrentEnvironmentToCloud()
+              .subscribe();
+          },
+          score: 1,
+          enabled: hasActiveEnvironment && activeEnvironmentIsLocal
         }
       );
     } else {

--- a/packages/app/src/renderer/app/services/environments.service.ts
+++ b/packages/app/src/renderer/app/services/environments.service.ts
@@ -1980,6 +1980,29 @@ export class EnvironmentsService {
   }
 
   /**
+   * Convert the current active local environment to a cloud environment
+   * In reality, closes the current environment and re-adds it as a cloud environment with the same data and uuid
+   *
+   * This is useful when the user wants to convert a local environment to cloud and keep
+   * the link between the local environment and the deployed instance (same uuid).
+   * This will be mostly used during the migration after 9.4.0 prohibits deployment of
+   * local environments to the cloud.
+   *
+   * @returns
+   */
+  public convertCurrentEnvironmentToCloud() {
+    const activeEnvironment = this.store.getActiveEnvironment();
+
+    if (this.store.getIsEnvCloud(activeEnvironment.uuid)) {
+      return EMPTY;
+    }
+
+    return this.closeEnvironment(activeEnvironment.uuid, true).pipe(
+      switchMap(() => this.addCloudEnvironment(activeEnvironment, true))
+    );
+  }
+
+  /**
    * Reorder an items list
    */
   public reorderItems(

--- a/packages/app/src/renderer/app/stores/store.ts
+++ b/packages/app/src/renderer/app/stores/store.ts
@@ -575,6 +575,15 @@ export class Store {
   }
 
   /**
+   * Check if the active environment is a local environment
+   *
+   * @returns
+   */
+  public getIsActiveEnvLocal(): boolean {
+    return !this.getIsActiveEnvCloud();
+  }
+
+  /**
    * Check if the active environment is a cloud environment
    *
    * @returns


### PR DESCRIPTION
To help with migration after 9.4.0, add a command palette entry to create a cloud env with the same uuids to keep the link between the existing instance and the local env

See #1818

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
