### PR TITLE
Inverse cloud logs replay order

### DIFF
--- a/packages/commons-server/src/libs/server/admin-api.ts
+++ b/packages/commons-server/src/libs/server/admin-api.ts
@@ -45,7 +45,10 @@ export const createAdminEndpoint = (
           ? parseInt(request.query.maxlogs, 10)
           : undefined;
       const logs = getLogs();
-      const limitedLogs = maxLogs ? logs.slice(0, maxLogs) : logs;
+      const limitedLogs =
+        maxLogs != null && !isNaN(maxLogs) && maxLogs > 0
+          ? logs.slice(maxLogs * -1)
+          : logs;
 
       return [
         ...replayableEvents,

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -587,17 +587,12 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
 
       this.emit('transaction-complete', transaction);
 
-      // store the transaction logs at beginning of the array
-      this.transactionLogs.unshift(transaction);
+      this.transactionLogs.push(transaction);
 
       // keep only the last n transactions
       if (this.transactionLogs.length > this.options.maxTransactionLogs) {
-        this.transactionLogs.pop();
-      }
-      if (this.transactionLogs.length > this.options.maxTransactionLogs) {
         this.transactionLogs = this.transactionLogs.slice(
-          0,
-          this.options.maxTransactionLogs
+          this.options.maxTransactionLogs * -1
         );
       }
     });


### PR DESCRIPTION
It's more correct to emit them in the order in which they were made, instead of reversing the order like in the app view. Closes #1966

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
