### PR TITLE
Pass the publicBaseUrl to the template parser

### DIFF
--- a/packages/commons-server/src/libs/response-rules-interpreter.ts
+++ b/packages/commons-server/src/libs/response-rules-interpreter.ts
@@ -47,7 +47,8 @@ export class ResponseRulesInterpreter {
     private environment: Environment,
     private processedDatabuckets: ProcessedDatabucket[],
     private globalVariables: Record<string, any>,
-    private envVarsPrefix: string
+    private envVarsPrefix: string,
+    private publicBaseUrl?: string
   ) {
     this.extractTargets();
   }
@@ -330,7 +331,8 @@ export class ResponseRulesInterpreter {
         request: requestMessage
           ? fromServerRequest(this.request, requestMessage)
           : this.request,
-        envVarsPrefix: this.envVarsPrefix
+        envVarsPrefix: this.envVarsPrefix,
+        publicBaseUrl: this.publicBaseUrl
       });
     } catch (_error) {
       return value;

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -848,7 +848,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
           this.environment,
           this.processedDatabuckets,
           this.globalVariables,
-          this.options.envVarsPrefix
+          this.options.envVarsPrefix,
+          this.options.publicBaseUrl
         ).chooseResponse(responseNumber, messageData);
 
         if (!enabledRouteResponse) {
@@ -953,7 +954,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
             processedDatabuckets: this.processedDatabuckets,
             globalVariables: this.globalVariables,
             request: finalRequest,
-            envVarsPrefix: this.options.envVarsPrefix
+            envVarsPrefix: this.options.envVarsPrefix,
+            publicBaseUrl: this.options.publicBaseUrl
           })
       );
 
@@ -968,7 +970,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         processedDatabuckets: this.processedDatabuckets,
         globalVariables: this.globalVariables,
         request: finalRequest,
-        envVarsPrefix: this.options.envVarsPrefix
+        envVarsPrefix: this.options.envVarsPrefix,
+        publicBaseUrl: this.options.publicBaseUrl
       });
     }
 
@@ -1021,7 +1024,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         environment: this.environment,
         processedDatabuckets: this.processedDatabuckets,
         globalVariables: this.globalVariables,
-        envVarPrefix: this.options.envVarsPrefix
+        envVarPrefix: this.options.envVarsPrefix,
+        publicBaseUrl: this.options.publicBaseUrl
       },
       request,
       handler
@@ -1052,7 +1056,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         this.environment,
         this.processedDatabuckets,
         this.globalVariables,
-        this.options.envVarsPrefix
+        this.options.envVarsPrefix,
+        this.options.publicBaseUrl
       ).chooseResponse(responseNumber);
 
       if (!enabledRouteResponse) {
@@ -1183,7 +1188,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         this.environment,
         this.processedDatabuckets,
         this.globalVariables,
-        this.options.envVarsPrefix
+        this.options.envVarsPrefix,
+        this.options.publicBaseUrl
       ).chooseResponse(this.requestNumbers[route.uuid]);
 
       if (!enabledRouteResponse) {
@@ -1338,7 +1344,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
             globalVariables: this.globalVariables,
             request: serverRequest,
             response,
-            envVarsPrefix: this.options.envVarsPrefix
+            envVarsPrefix: this.options.envVarsPrefix,
+            publicBaseUrl: this.options.publicBaseUrl
           });
 
           // build the callback chain by appending current route response UUID
@@ -1445,7 +1452,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               globalVariables: this.globalVariables,
               request: serverRequest,
               response,
-              envVarsPrefix: this.options.envVarsPrefix
+              envVarsPrefix: this.options.envVarsPrefix,
+              publicBaseUrl: this.options.publicBaseUrl
             });
           }
 
@@ -1512,7 +1520,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
           globalVariables: this.globalVariables,
           request: fromExpressRequest(request),
           response,
-          envVarsPrefix: this.options.envVarsPrefix
+          envVarsPrefix: this.options.envVarsPrefix,
+          publicBaseUrl: this.options.publicBaseUrl
         });
       }
 
@@ -1617,7 +1626,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               globalVariables: this.globalVariables,
               request: serverRequest,
               response,
-              envVarsPrefix: this.options.envVarsPrefix
+              envVarsPrefix: this.options.envVarsPrefix,
+              publicBaseUrl: this.options.publicBaseUrl
             });
 
             this.applyResponseLocals(response);
@@ -1924,7 +1934,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
           processedDatabuckets: this.processedDatabuckets,
           globalVariables: this.globalVariables,
           request: fromExpressRequest(request),
-          envVarsPrefix: this.options.envVarsPrefix
+          envVarsPrefix: this.options.envVarsPrefix,
+          publicBaseUrl: this.options.publicBaseUrl
         });
       } catch (error: any) {
         this.emit('error', ServerErrorCodes.HEADER_PARSING_ERROR, error, {
@@ -2027,7 +2038,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         environment,
         processedDatabuckets: this.processedDatabuckets,
         globalVariables: this.globalVariables,
-        envVarsPrefix: this.options.envVarsPrefix
+        envVarsPrefix: this.options.envVarsPrefix,
+        publicBaseUrl: this.options.publicBaseUrl
       });
 
     if (
@@ -2117,7 +2129,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               environment,
               processedDatabuckets: this.processedDatabuckets,
               globalVariables: this.globalVariables,
-              envVarsPrefix: this.options.envVarsPrefix
+              envVarsPrefix: this.options.envVarsPrefix,
+              publicBaseUrl: this.options.publicBaseUrl
             });
 
             const JSONParsedContent = JSON.parse(templateParsedContent);
@@ -2340,7 +2353,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
               processedDatabuckets: this.processedDatabuckets,
               globalVariables: this.globalVariables,
               request: fromExpressRequest(request),
-              envVarsPrefix: this.options.envVarsPrefix
+              envVarsPrefix: this.options.envVarsPrefix,
+              publicBaseUrl: this.options.publicBaseUrl
             });
 
             const JSONParsedcontent = JSON.parse(content);
@@ -2436,7 +2450,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       processedDatabuckets: this.processedDatabuckets,
       globalVariables: this.globalVariables,
       request,
-      envVarsPrefix: this.options.envVarsPrefix
+      envVarsPrefix: this.options.envVarsPrefix,
+      publicBaseUrl: this.options.publicBaseUrl
     });
 
     // Determine if the path is absolute or relative

--- a/packages/commons-server/src/libs/server/ws.ts
+++ b/packages/commons-server/src/libs/server/ws.ts
@@ -26,6 +26,7 @@ export type ServerContext = {
   processedDatabuckets: ProcessedDatabucket[];
   globalVariables: Record<string, any>;
   envVarPrefix: string;
+  publicBaseUrl?: string;
 };
 
 /**
@@ -65,7 +66,8 @@ export class WsRunningInstance {
         this.serverContext.environment,
         this.serverContext.processedDatabuckets,
         this.serverContext.globalVariables,
-        this.serverContext.envVarPrefix
+        this.serverContext.envVarPrefix,
+        this.serverContext.publicBaseUrl
       ).chooseResponse(responseNumber);
 
       if (!enabledRouteResponse) {

--- a/packages/commons-server/src/libs/template-parser.ts
+++ b/packages/commons-server/src/libs/template-parser.ts
@@ -34,7 +34,8 @@ export const TemplateParser = function ({
   globalVariables,
   request,
   response,
-  envVarsPrefix
+  envVarsPrefix,
+  publicBaseUrl
 }: {
   shouldOmitDataHelper: boolean;
   content: string;
@@ -44,6 +45,7 @@ export const TemplateParser = function ({
   request?: ServerRequest;
   response?: Response;
   envVarsPrefix: string;
+  publicBaseUrl?: string;
 }): string {
   let helpers = {
     ...FakerWrapper,
@@ -62,7 +64,7 @@ export const TemplateParser = function ({
   if (request) {
     helpers = {
       ...helpers,
-      ...RequestHelpers(request, environment)
+      ...RequestHelpers(request, environment, publicBaseUrl)
     };
   }
 

--- a/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
+++ b/packages/commons-server/src/libs/templating-helpers/request-helpers.ts
@@ -22,7 +22,8 @@ export const requestHelperNames: (keyof ReturnType<typeof RequestHelpers>)[] = [
 
 export const RequestHelpers = function (
   request: ServerRequest,
-  environment: Environment
+  environment: Environment,
+  publicBaseUrl?: string
 ) {
   return {
     // get json property from body
@@ -143,6 +144,11 @@ export const RequestHelpers = function (
       const prefix = environment.endpointPrefix
         ? `/${environment.endpointPrefix}`
         : '';
+
+      if (publicBaseUrl) {
+        return `${publicBaseUrl}${prefix}`;
+      }
+
       const protocol = environment.tlsOptions.enabled ? 'https' : 'http';
 
       return `${protocol}://${request.hostname}:${environment.port}${prefix}`;

--- a/packages/commons-server/test/specs/templating-helpers/request-helpers.test.ts
+++ b/packages/commons-server/test/specs/templating-helpers/request-helpers.test.ts
@@ -1056,6 +1056,34 @@ describe('Request helpers', () => {
       });
       strictEqual(parseResult, 'https://localhost:3001');
     });
+
+    it('should return the publicBaseUrl if provided', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: '{{baseUrl}}',
+        environment: {
+          tlsOptions: {
+            enabled: false,
+            type: 'CERT',
+            pfxPath: '',
+            certPath: '',
+            keyPath: '',
+            caPath: '',
+            passphrase: ''
+          },
+          port: 3001,
+          endpointPrefix: 'myapi'
+        } as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {
+          hostname: 'localhost'
+        } as any,
+        envVarsPrefix: '',
+        publicBaseUrl: 'https://subdomain.mockoon.app:12345'
+      });
+      strictEqual(parseResult, 'https://subdomain.mockoon.app:12345/myapi');
+    });
   });
 
   describe('Helper: header', () => {


### PR DESCRIPTION
Allow the baseUrl helper to return a public base URL instead of a constructed one (when the mock is deployed on  a public domain for example).

Closes #1488

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #{issue_number}
