### PR TITLE
fix: ensure stringify handles nested SafeStrings

### DIFF
--- a/packages/commons-server/src/libs/templating-helpers/helpers/stringify.ts
+++ b/packages/commons-server/src/libs/templating-helpers/helpers/stringify.ts
@@ -12,7 +12,17 @@ const stringify = function (data: unknown, options: HelperOptions) {
       data = fromSafeString(data);
     }
 
-    return JSON.stringify(data, null, 2);
+    return JSON.stringify(
+      data,
+      (_, value) => {
+        if (value instanceof SafeString) {
+          return fromSafeString(value);
+        }
+
+        return value;
+      },
+      2
+    );
   } else {
     return data;
   }

--- a/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
+++ b/packages/commons-server/test/specs/templating-helpers/helpers.test.ts
@@ -2836,6 +2836,27 @@ describe('Template parser', () => {
       });
       strictEqual(parseResult, '{"result": "{\\"myarr\\":[1,2,3]}" }');
     });
+
+    it('should output objects as string, and support safestrings nested in objects', () => {
+      const parseResult = TemplateParser({
+        shouldOmitDataHelper: false,
+        content: `{{{
+          stringify (object
+            foo = 'abc'
+            bar = (base64 'abc')
+          )
+        }}}`,
+        environment: {} as any,
+        processedDatabuckets: [],
+        globalVariables: {},
+        request: {} as any,
+        envVarsPrefix: ''
+      });
+
+      const parsedResult = JSON.parse(parseResult);
+      strictEqual(parsedResult.foo, 'abc');
+      strictEqual(parsedResult.bar, 'YWJj');
+    });
   });
 
   describe('Helper: jsonParse', () => {


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix/{issue_number}-description.
- Follow the template!
 -->

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->
The stringify helper currently uses `JSON.stringify(data, null, 2)`. When helpers like `base64` or `padStart` are used inside an `(object ...)` helper, they return Handlebars SafeString objects.

While `JSON.stringify` works for primitive strings at the top level, it treats nested `SafeString` as regular JavaScript objects during serialization, resulting in an unexpected `{"string":"..."}` output for nested values.


I have updated the `stringify` helper to use a JSON replacer function. This ensures that any `SafeString` encountered during the recursive serialization process (at any nesting depth) is correctly converted back to a primitive string using the existing `fromSafeString` utility.

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

<!-- Link to the original issue -->

Closes #2060 
