### PR TITLE
fix: Retain literal boolean values in OpenAPI schemas

### DIFF
--- a/packages/app/test/data/res/import-openapi/references/petstore-v2.json
+++ b/packages/app/test/data/res/import-openapi/references/petstore-v2.json
@@ -509,7 +509,7 @@
       "responses": [
         {
           "uuid": "334ea3fc-0c8d-4a07-b253-a51abbc612b9",
-          "body": "{\n  \"id\": {{faker 'number.int' max=99999}},\n  \"petId\": {{faker 'number.int' max=99999}},\n  \"quantity\": {{faker 'number.int' max=99999}},\n  \"shipDate\": \"{{faker 'date.recent' 365}}\",\n  \"status\": \"{{oneOf 'placed' 'approved' 'delivered'}}\",\n  \"complete\": {{faker 'datatype.boolean'}}\n}",
+          "body": "{\n  \"id\": {{faker 'number.int' max=99999}},\n  \"petId\": {{faker 'number.int' max=99999}},\n  \"quantity\": {{faker 'number.int' max=99999}},\n  \"shipDate\": \"{{faker 'date.recent' 365}}\",\n  \"status\": \"{{oneOf 'placed' 'approved' 'delivered'}}\",\n  \"complete\": false\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "successful operation",
@@ -569,7 +569,7 @@
       "responses": [
         {
           "uuid": "9909f0cc-6af9-4b5e-aec9-30d02b4b8482",
-          "body": "{\n  \"id\": {{faker 'number.int' max=99999}},\n  \"petId\": {{faker 'number.int' max=99999}},\n  \"quantity\": {{faker 'number.int' max=99999}},\n  \"shipDate\": \"{{faker 'date.recent' 365}}\",\n  \"status\": \"{{oneOf 'placed' 'approved' 'delivered'}}\",\n  \"complete\": {{faker 'datatype.boolean'}}\n}",
+          "body": "{\n  \"id\": {{faker 'number.int' max=99999}},\n  \"petId\": {{faker 'number.int' max=99999}},\n  \"quantity\": {{faker 'number.int' max=99999}},\n  \"shipDate\": \"{{faker 'date.recent' 365}}\",\n  \"status\": \"{{oneOf 'placed' 'approved' 'delivered'}}\",\n  \"complete\": false\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "successful operation",

--- a/packages/commons/src/libs/openapi-converter.ts
+++ b/packages/commons/src/libs/openapi-converter.ts
@@ -879,12 +879,12 @@ export class OpenApiConverter {
       }
 
       // return example if any
-      if (schema.example) {
+      if (schema.example !== undefined) {
         return schema.example;
       }
 
       // return default value if any
-      if (schema.default) {
+      if (schema.default !== undefined) {
         return schema.default;
       }
 

--- a/packages/commons/test/specs/openapi-converter.test.ts
+++ b/packages/commons/test/specs/openapi-converter.test.ts
@@ -238,4 +238,63 @@ describe('OpenAPI converter', () => {
       '{\n  "myBooleanEnum": {{oneOf true false}}\n}'
     );
   });
+
+  it('should retain boolean values in example and default', async () => {
+    const openApiConverter = new OpenApiConverter();
+    const booleanValueSpec = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'boolean-value', version: '1.0.0' },
+      paths: {
+        '/boolean-value': {
+          get: {
+            responses: {
+              200: {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        myFalseDefault: {
+                          type: 'boolean',
+                          default: false
+                        },
+                        myTrueDefault: {
+                          type: 'boolean',
+                          default: true
+                        },
+                        myFalseExample: {
+                          type: 'boolean',
+                          example: false
+                        },
+                        myTrueExample: {
+                          type: 'boolean',
+                          example: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const environment =
+      await openApiConverter.convertFromOpenAPI(booleanValueSpec);
+    const route = environment?.routes.find(
+      (currentRoute) => currentRoute.endpoint === 'boolean-value'
+    );
+
+    const expectedBody = `{
+  "myFalseDefault": false,
+  "myTrueDefault": true,
+  "myFalseExample": false,
+  "myTrueExample": true
+}`;
+
+    strictEqual(route?.responses[0].body, expectedBody);
+  });
 });


### PR DESCRIPTION
When importing an OpenAPI spec, if a `SchemaObject` is a `boolean` type and has an `example` or `default` value of `false`, it is not returned as the literal value in the data format and instead is replaced by a faker template.

When the value is `true` it does not replace it. This is a small fix to replace the truthy check on these properties with an explicit `undefined` comparison so supplied values are consistently parsed.

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [x] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)

Closes #2159 
