### PR TITLE
Surface websocket messages in app logs

### DIFF
--- a/packages/app/src/main/libs/server-management.ts
+++ b/packages/app/src/main/libs/server-management.ts
@@ -134,6 +134,38 @@ export class ServerInstance {
       }
     });
 
+    server.on(
+      'ws-message-received',
+      (request: InFlightRequest, message: string) => {
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(
+            'APP_SERVER_EVENT',
+            this.environment.uuid,
+            'ws-message-received',
+            { inflightRequest: request, websocketMessage: message }
+          );
+        }
+      }
+    );
+
+    server.on(
+      'ws-closed',
+      (request: InFlightRequest, wsCode: number, reason?: string | null) => {
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(
+            'APP_SERVER_EVENT',
+            this.environment.uuid,
+            'ws-closed',
+            {
+              inflightRequest: request,
+              websocketCode: wsCode,
+              websocketReason: reason
+            }
+          );
+        }
+      }
+    );
+
     server.on('transaction-complete', (transaction: Transaction) => {
       if (!mainWindow.isDestroyed()) {
         mainWindow.webContents.send(

--- a/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.html
+++ b/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.html
@@ -256,6 +256,22 @@
                       {{ selectedLog.protocol | uppercase }}
                     </span>
                   </div>
+                  <div class="environment-logs-content-item">
+                    <strong>WebSocket event:</strong>
+                    {{ getWebSocketEventLabel(selectedLog) }}
+                  </div>
+                  @if (getWebSocketCloseCode(selectedLog); as closeCode) {
+                    <div class="environment-logs-content-item">
+                      <strong>Close code:</strong>
+                      {{ closeCode }}
+                    </div>
+                    @if (getWebSocketCloseReason(selectedLog); as closeReason) {
+                      <div class="environment-logs-content-item">
+                        <strong>Close reason:</strong>
+                        {{ closeReason }}
+                      </div>
+                    }
+                  }
                 }
                 @if (selectedLog.protocol !== 'ws') {
                   <div class="environment-logs-content-item">
@@ -412,7 +428,12 @@
                   "
                 />
 
-                Body {{ !selectedLog?.request?.body ? '(none)' : '' }}
+                {{
+                  selectedLog?.websocketEvent?.type === 'message'
+                    ? 'Message'
+                    : 'Body'
+                }}
+                {{ !selectedLog?.request?.body ? '(none)' : '' }}
               </div>
               <div [ngbCollapse]="collapseStates['request.body']">
                 <div class="environment-logs-content-item">

--- a/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.ts
+++ b/packages/app/src/renderer/app/components/environment-logs/environment-logs.component.ts
@@ -224,7 +224,7 @@ export class EnvironmentLogsComponent implements OnInit {
         if (search) {
           result = result.filter((log) =>
             textFilter(
-              `${log.method} ${log.url} ${log.response.status} ${log.response.statusMessage} ${log.request.query} ${this.datePipe.transform(log.timestampMs, this.dateFormat)} ${log.proxied ? 'proxied' : ''}`,
+              `${log.method} ${log.url} ${log.response.status} ${log.response.statusMessage} ${log.request.query} ${log.request.body} ${log.response.body} ${this.datePipe.transform(log.timestampMs, this.dateFormat)} ${log.proxied ? 'proxied' : ''}`,
               search
             )
           );
@@ -398,5 +398,29 @@ export class EnvironmentLogsComponent implements OnInit {
       log.routeUUID,
       log.routeResponseUUID
     );
+  }
+
+  public getWebSocketEventLabel(log: EnvironmentLog) {
+    if (log.websocketEvent?.type === 'message') {
+      return 'Message received';
+    }
+
+    if (log.websocketEvent?.type === 'closed') {
+      return 'Connection closed';
+    }
+
+    return 'Connection opened';
+  }
+
+  public getWebSocketCloseCode(log: EnvironmentLog) {
+    return log.websocketEvent?.type === 'closed'
+      ? log.websocketEvent.code
+      : null;
+  }
+
+  public getWebSocketCloseReason(log: EnvironmentLog) {
+    return log.websocketEvent?.type === 'closed'
+      ? log.websocketEvent.reason
+      : null;
   }
 }

--- a/packages/app/src/renderer/app/models/environment-logs.model.ts
+++ b/packages/app/src/renderer/app/models/environment-logs.model.ts
@@ -24,6 +24,11 @@ export type EnvironmentLogResponse = {
 
 export type EnvironmentLogOrigin = 'local' | 'cloud';
 
+export type EnvironmentLogWebSocketEvent =
+  | { type: 'connection' }
+  | { type: 'message'; message: string }
+  | { type: 'closed'; code: number; reason?: string | null };
+
 export type EnvironmentLog = {
   origin: EnvironmentLogOrigin;
   uuid: string;
@@ -37,6 +42,7 @@ export type EnvironmentLog = {
   route: string;
   method: keyof typeof Methods;
   proxied: boolean;
+  websocketEvent?: EnvironmentLogWebSocketEvent;
   request: EnvironmentLogRequest;
   response: EnvironmentLogResponse;
 };

--- a/packages/app/src/renderer/app/models/main-api.model.ts
+++ b/packages/app/src/renderer/app/models/main-api.model.ts
@@ -116,6 +116,9 @@ export interface MainAPIModel {
         originalError?: Error;
         transaction?: Transaction;
         inflightRequest?: InFlightRequest;
+        websocketMessage?: string;
+        websocketCode?: number;
+        websocketReason?: string | null;
         dataBuckets?: ProcessedDatabucketWithoutValue[];
       }
     ) => void

--- a/packages/app/src/renderer/app/services/data.service.ts
+++ b/packages/app/src/renderer/app/services/data.service.ts
@@ -17,7 +17,8 @@ import {
 } from '@mockoon/commons';
 import {
   EnvironmentLog,
-  EnvironmentLogOrigin
+  EnvironmentLogOrigin,
+  EnvironmentLogWebSocketEvent
 } from 'src/renderer/app/models/environment-logs.model';
 import { LoggerService } from 'src/renderer/app/services/logger-service';
 import { MigrationService } from 'src/renderer/app/services/migration.service';
@@ -84,6 +85,7 @@ export class DataService {
       url: request.request.urlPath,
       route: request.request.route,
       protocol: 'ws',
+      websocketEvent: { type: 'connection' },
       request: {
         isInvalidJson: false,
         query: request.request.query,
@@ -99,6 +101,57 @@ export class DataService {
         statusMessage: 'Switching Protocols',
         headers: [],
         body: '{}',
+        binaryBody: false,
+        isInvalidJson: false
+      },
+      proxied: false
+    };
+  }
+
+  /**
+   * Creates a new environment log record from a WebSocket event.
+   *
+   * @param request
+   */
+  public formatLogFromWebSocketEvent(
+    request: InFlightRequest,
+    origin: EnvironmentLogOrigin,
+    websocketEvent: EnvironmentLogWebSocketEvent
+  ): EnvironmentLog {
+    const messageBody =
+      websocketEvent.type === 'message' ? websocketEvent.message : '';
+    const closeReason =
+      websocketEvent.type === 'closed' ? websocketEvent.reason || '' : '';
+    const status = websocketEvent.type === 'closed' ? websocketEvent.code : 101;
+    const statusMessage =
+      websocketEvent.type === 'message'
+        ? 'WebSocket Message'
+        : closeReason || 'WebSocket Closed';
+
+    return {
+      origin,
+      uuid: generateUUID(),
+      routeUUID: request.routeUUID,
+      timestampMs: Date.now(),
+      method: request.request.method as EnvironmentLog['method'],
+      url: request.request.urlPath,
+      route: request.request.route,
+      protocol: 'ws',
+      websocketEvent,
+      request: {
+        isInvalidJson: false,
+        query: request.request.query,
+        body: messageBody,
+        bodyUnformatted: messageBody,
+        headers: request.request.headers,
+        params: request.request.params || [],
+        queryParams: request.request.queryParams || []
+      },
+      response: {
+        status,
+        statusMessage,
+        headers: [],
+        body: closeReason,
         binaryBody: false,
         isInvalidJson: false
       },

--- a/packages/app/src/renderer/app/services/environments.service.ts
+++ b/packages/app/src/renderer/app/services/environments.service.ts
@@ -2465,10 +2465,16 @@ export class EnvironmentsService {
             serverTransactionPayload.origin
           );
         } else if (serverTransactionPayload.inflightRequest) {
-          formattedLog = this.dataService.formatLogFromInFlightRequest(
-            serverTransactionPayload.inflightRequest,
-            serverTransactionPayload.origin
-          );
+          formattedLog = serverTransactionPayload.websocketEvent
+            ? this.dataService.formatLogFromWebSocketEvent(
+                serverTransactionPayload.inflightRequest,
+                serverTransactionPayload.origin,
+                serverTransactionPayload.websocketEvent
+              )
+            : this.dataService.formatLogFromInFlightRequest(
+                serverTransactionPayload.inflightRequest,
+                serverTransactionPayload.origin
+              );
         }
 
         if (!formattedLog) {
@@ -2485,7 +2491,9 @@ export class EnvironmentsService {
         if (
           this.eventsService.logsRecording$.value[
             serverTransactionPayload.environmentUUID
-          ] === true
+          ] === true &&
+          (!serverTransactionPayload.websocketEvent ||
+            serverTransactionPayload.websocketEvent.type === 'connection')
         ) {
           this.createRouteFromLog(
             serverTransactionPayload.environmentUUID,

--- a/packages/app/src/renderer/app/services/events.service.ts
+++ b/packages/app/src/renderer/app/services/events.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { InFlightRequest, Transaction } from '@mockoon/commons';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { FocusableInputs } from 'src/renderer/app/enums/ui.enum';
-import { EnvironmentLogOrigin } from 'src/renderer/app/models/environment-logs.model';
+import {
+  EnvironmentLogOrigin,
+  EnvironmentLogWebSocketEvent
+} from 'src/renderer/app/models/environment-logs.model';
 
 @Injectable({ providedIn: 'root' })
 export class EventsService {
@@ -14,6 +17,7 @@ export class EventsService {
     environmentUUID: string;
     transaction?: Transaction;
     inflightRequest?: InFlightRequest;
+    websocketEvent?: EnvironmentLogWebSocketEvent;
     origin: EnvironmentLogOrigin;
   }>();
 }

--- a/packages/app/src/renderer/app/services/server.service.ts
+++ b/packages/app/src/renderer/app/services/server.service.ts
@@ -341,6 +341,39 @@ export class ServerService {
         }
         break;
 
+      case 'ws-message-received':
+        if (data.inflightRequest && data.websocketMessage !== undefined) {
+          this.zone.run(() => {
+            this.eventsService.serverTransaction$.next({
+              environmentUUID: environmentUuid,
+              inflightRequest: data.inflightRequest,
+              websocketEvent: {
+                type: 'message',
+                message: data.websocketMessage
+              },
+              origin
+            });
+          });
+        }
+        break;
+
+      case 'ws-closed':
+        if (data.inflightRequest && data.websocketCode !== undefined) {
+          this.zone.run(() => {
+            this.eventsService.serverTransaction$.next({
+              environmentUUID: environmentUuid,
+              inflightRequest: data.inflightRequest,
+              websocketEvent: {
+                type: 'closed',
+                code: data.websocketCode,
+                reason: data.websocketReason
+              },
+              origin
+            });
+          });
+        }
+        break;
+
       case 'transaction-complete':
         if (data.transaction) {
           this.zone.run(() => {

--- a/packages/app/test/specs/ws.spec.ts
+++ b/packages/app/test/specs/ws.spec.ts
@@ -2,6 +2,7 @@ import { fail } from 'node:assert';
 import { promises as fs } from 'node:fs';
 import environments from '../libs/environments';
 import environmentsSettings from '../libs/environments-settings';
+import environmentsLogs from '../libs/environments-logs';
 import http from '../libs/http';
 import navigation from '../libs/navigation';
 import { WsConnection, withTimeout } from '../libs/ws';
@@ -50,6 +51,21 @@ describe('WebSockets', () => {
       await ws.assertReply(
         '{ "message": "Hello world 2222!" }',
         'ECHO: { "message": "Hello world 2222!" }'
+      );
+
+      await navigation.switchView('ENV_LOGS');
+      await browser.pause(500);
+      await environmentsLogs.select(1);
+      await environmentsLogs.assertLogMenu(1, 'WS', '/ws-env/test/ws/echo');
+      await environmentsLogs.assertLogItem(
+        'WebSocket event: Message received',
+        'request',
+        2,
+        3
+      );
+      await environmentsLogs.assertLogBody(
+        '{ "message": "Hello world 2222!" }',
+        'request'
       );
 
       ws.close();


### PR DESCRIPTION
Closes #2171

**Technical implementation details**

This surfaces WebSocket activity in the app Logs view after the initial upgrade:

- forwards `ws-message-received` and `ws-closed` from the Electron main server bridge through `APP_SERVER_EVENT`
- adds a typed WebSocket event payload to the renderer log event flow
- formats message/close events as `ws` `EnvironmentLog` entries, with the received message shown in the request body and close code/reason shown in the log details
- keeps route creation from log recording limited to the connection event, so message/close log entries do not create duplicate mock routes
- adds a desktop UI spec assertion for seeing a received WebSocket message in the Logs view

Duplicate/fit check: #2171 is open and unassigned, and the only issue comment says WebSocket messages are not surfaced in the UI yet. I also checked all PR states for `2171 Support websocket log after upgrade` and found no existing PR. I noticed the issue is currently unassigned; happy to adjust or close if you would rather discuss/assign first.

AI assistance disclosure: I used Codex/AI assistance to prepare this patch, then checked the implementation path and ran the verification below locally.

Verification run locally:

- `npm ci`
- `npm run build:libs`
- `npm run build:ci:main --workspace=@mockoon/app`
- `npm run lint --workspace=@mockoon/app`
- `npm run build:ci:renderer --workspace=@mockoon/app`
- `git diff --check`

I did not run the desktop WebdriverIO spec locally because the repo docs require packaging the desktop app first for platform tests; the new assertion is included for CI/packaged test coverage.

**Checklist**

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [x] desktop UI automated tests added (@mockoon/app)
