### PR TITLE
Fix path traversal in file path

### DIFF
--- a/packages/app/test/specs/file.spec.ts
+++ b/packages/app/test/specs/file.spec.ts
@@ -48,7 +48,7 @@ describe('File serving', () => {
           status: 200,
           body: {
             contains:
-              'Error while serving the content: Access to relative path outside of the environment base directory'
+              'Error while serving the content: Access to relative path outside of the allowed base directory'
           }
         }
       });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -379,7 +379,7 @@ All of `mockoon-cli start` flags (`--port`, etc.) must be provided when running 
 
 To load the Mockoon data, you can either mount a local data file and pass `mockoon-cli start` flags at the end of the command:
 
-`docker run -d --mount type=bind,source=/home/your-data-file.json,target=/data,readonly -p 3000:3000 mockoon/cli:latest --data data --port 3000`
+`docker run -d --mount type=bind,source=/home/your-data-file.json,target=/home/mockoon/data/your-data-file.json,readonly -p 3000:3000 mockoon/cli:latest --data /home/mockoon/data/your-data-file.json --port 3000`
 
 Or directly pass a URL to the `mockoon-cli start` command, without mounting a local data file:
 
@@ -394,7 +394,7 @@ You can also use `docker-compose` with a `docker-compose.yml` file:
 ```
 mock-server:
   image: mockoon/cli:latest
-  command: ["--data", "data", "--port", "3000"]
+  command: ["--data", "/home/mockoon/data/your-data-file.json", "--port", "3000"]
   healthcheck:
     test: ["CMD-SHELL", "curl -f http://localhost:3000/your-healthcheck-route || exit 1"]
     interval: 30s
@@ -402,7 +402,7 @@ mock-server:
     retries: 2
     start_period: 10s
   volumes:
-    - /home/your-data-file.json:/data:readonly
+    - /home/your-data-file.json:/home/mockoon/data/your-data-file.json:readonly
 ```
 
 > Please note that our [Docker image includes an `ENTRYPOINT`](https://github.com/mockoon/mockoon/blob/main/packages/cli/docker/Dockerfile#L16) that you may override or not. If you don't override it, and use Docker compose `command`, do not include `mockoon-cli start` as it is already included in the `ENTRYPOINT`.

--- a/packages/cli/docker/Dockerfile
+++ b/packages/cli/docker/Dockerfile
@@ -15,4 +15,4 @@ EXPOSE 3000
 
 ENTRYPOINT ["mockoon-cli", "start", "--disable-log-to-file"]
 
-# Usage: docker run --mount type=bind,source="$(pwd)"/dataFile.json,target=/data,readonly -p <port>:<port> mockoon-test -d data
+# Usage: docker run -d --mount type=bind,source=/home/your-data-file.json,target=/home/mockoon/data/your-data-file.json,readonly -p 3000:3000 mockoon/cli:latest --data /home/mockoon/data/your-data-file.json --port 3000

--- a/packages/cli/test/specs/file-serving.test.ts
+++ b/packages/cli/test/specs/file-serving.test.ts
@@ -35,23 +35,19 @@ describe('File serving', () => {
     ok(responseBody.includes('"name": "mock1"'));
   });
 
-  it('should not get the file content with a relative path from the environment file if dynamic)', async () => {
-    const { instance, output } = await spawnCli([
+  it('should get the file content with a relative templated path when it stays within the static base', async () => {
+    const { instance } = await spawnCli([
       'start',
       '--data',
       './test/data/envs/file.json'
     ]);
 
-    await (await fetch('http://localhost:3000/param2/file1')).text();
+    const responseBody = await (
+      await fetch('http://localhost:3000/param2/file1')
+    ).text();
 
     instance.kill();
 
-    const { stdout } = await output;
-
-    ok(
-      stdout.includes(
-        'Error while serving the content: Access to relative path outside of the environment base directory'
-      )
-    );
+    ok(responseBody.includes('filecontent'));
   });
 });

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -50,7 +50,7 @@ import {
 } from 'https';
 import killable from 'killable';
 import { AddressInfo, isIPv6 } from 'node:net';
-import { basename, extname, isAbsolute, resolve } from 'path';
+import { basename, extname, isAbsolute, parse, relative, resolve } from 'path';
 import { parse as qsParse } from 'qs';
 import rangeParser from 'range-parser';
 import { Readable } from 'stream';
@@ -2313,13 +2313,21 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
    * @returns
    */
   private getSafeFilePath(filePath: string, request?: ServerRequest) {
+    const environmentBaseDir = resolve(this.options.environmentDirectory);
     const resolvePath = (path: string) => {
       const isPathAbsolute = isAbsolute(path);
 
-      return isPathAbsolute
-        ? resolve(path)
-        : resolve(this.options.environmentDirectory, path);
+      return isPathAbsolute ? resolve(path) : resolve(environmentBaseDir, path);
     };
+    const isPathInsideBase = (basePath: string, candidatePath: string) => {
+      const relativePath = relative(basePath, candidatePath);
+
+      return (
+        relativePath === '' ||
+        (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+      );
+    };
+    const isFileSystemRoot = (path: string) => path === parse(path).root;
     // Convert backslashes to forward slashes (Windows compatibility)
     const rawFilePath = filePath.replace(/\\(?!\.)/g, '/');
 
@@ -2333,7 +2341,9 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
 
     // Extract static base from templated string (before first {{...}})
     const staticBaseMatch = rawFilePath.match(/^([^{}]+)/);
-    const staticBaseDir = staticBaseMatch ? resolve(staticBaseMatch[1]) : null;
+    const staticBaseDir = staticBaseMatch?.[1]
+      ? resolvePath(staticBaseMatch[1])
+      : null;
 
     const parsedFilePath = TemplateParser({
       shouldOmitDataHelper: false,
@@ -2349,21 +2359,21 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     // Determine if the path is absolute or relative
     const isPathAbsolute = isAbsolute(parsedFilePath);
     const resolvedPath = resolvePath(parsedFilePath);
+    const allowedBaseDir =
+      staticBaseDir ?? (!isPathAbsolute ? environmentBaseDir : null);
 
-    if (isPathAbsolute) {
-      // Absolute paths must stay within their original static base
-      if (!staticBaseDir || !resolvedPath.startsWith(staticBaseDir)) {
-        throw new Error(
-          `Access to absolute path outside of the original static base directory (${resolvedPath})`
-        );
-      }
-    } else {
-      // Relative paths must stay within the environment base directory
-      if (!resolvedPath.startsWith(this.options.environmentDirectory)) {
-        throw new Error(
-          `Access to relative path outside of the environment base directory (${resolvedPath})`
-        );
-      }
+    if (!allowedBaseDir || isFileSystemRoot(allowedBaseDir)) {
+      throw new Error(
+        `Templated file path requires a non-root base directory (${resolvedPath})`
+      );
+    }
+
+    if (!isPathInsideBase(allowedBaseDir, resolvedPath)) {
+      throw new Error(
+        isPathAbsolute
+          ? `Access to absolute path outside of the original static base directory (${resolvedPath})`
+          : `Access to relative path outside of the allowed base directory (${resolvedPath})`
+      );
     }
 
     return resolvedPath;

--- a/packages/commons-server/test/specs/server/server-file-serving.test.ts
+++ b/packages/commons-server/test/specs/server/server-file-serving.test.ts
@@ -1,7 +1,9 @@
 import { BodyTypes, Environment, RouteType } from '@mockoon/commons';
-import { equal } from 'node:assert';
+import { equal, throws } from 'node:assert';
+import { parse as pathParse, resolve as pathResolve } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 import { MockoonServer } from '../../../src';
+import { ServerRequest } from '../../../src/libs/requests';
 
 describe('Server file serving', () => {
   const environment: Environment = {
@@ -151,6 +153,101 @@ describe('Server file serving', () => {
 
     after(() => {
       server.stop();
+    });
+  });
+
+  describe('Templated file path safety', () => {
+    const buildRequest = (query: Record<string, string>): ServerRequest => ({
+      body: undefined,
+      cookies: {},
+      header: () => undefined,
+      headers: {},
+      get: () => undefined,
+      hostname: 'localhost',
+      ip: '127.0.0.1',
+      method: 'GET',
+      originalPath: '/test',
+      originalRequest: {},
+      params: {},
+      query,
+      stringBody: ''
+    });
+    const callGetSafeFilePath = (
+      server: MockoonServer,
+      filePath: string,
+      request?: ServerRequest
+    ) =>
+      (
+        server as unknown as {
+          getSafeFilePath: (input: string, req?: ServerRequest) => string;
+        }
+      ).getSafeFilePath(filePath, request);
+
+    it('should block absolute templated paths escaping to a sibling directory with a shared prefix', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathResolve('./test/data/environments')
+      });
+      const publicDir = pathResolve('./test/data/public');
+
+      throws(
+        () =>
+          callGetSafeFilePath(
+            server,
+            `${publicDir}/{{queryParam 'name'}}`,
+            buildRequest({ name: '../public_backup/secret.txt' })
+          ),
+        /outside of the original static base directory/
+      );
+    });
+
+    it('should block relative templated paths from escaping a nested static base when the environment directory is root', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathParse(pathResolve('./test/data')).root
+      });
+
+      throws(
+        () =>
+          callGetSafeFilePath(
+            server,
+            `./static/{{queryParam 'name'}}`,
+            buildRequest({ name: '../static_secret.txt' })
+          ),
+        /outside of the allowed base directory/
+      );
+    });
+
+    it('should reject templated file paths when the only allowed base directory is the filesystem root', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathParse(pathResolve('./test/data')).root
+      });
+
+      throws(
+        () =>
+          callGetSafeFilePath(
+            server,
+            `./{{queryParam 'name'}}`,
+            buildRequest({ name: 'test.data' })
+          ),
+        /requires a non-root base directory/
+      );
+    });
+
+    it('should allow templated relative paths that stay within their static base', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathParse(pathResolve('./test/data')).root
+      });
+
+      equal(
+        callGetSafeFilePath(
+          server,
+          `./static/{{queryParam 'name'}}`,
+          buildRequest({ name: 'asset.txt' })
+        ),
+        pathResolve(
+          pathParse(pathResolve('./test/data')).root,
+          'static/asset.txt'
+        )
+      );
     });
   });
 });


### PR DESCRIPTION
This PR fixes a [path traversal vulnerability](https://github.com/mockoon/mockoon/security/advisories/GHSA-8wqc-v2q8-vff2).  A [first fix](https://github.com/mockoon/mockoon/security/advisories/GHSA-w7f9-wqc4-3wxr) was done last year but wasn't covering some specific cases: 

- siblings folders starting with the same string (due to the use of `startWith`).
- when the current path resolves to root (Docker container).

Your deployment may be vulnerable in the above cases, if you use templating helpers accessing "user content" (`body`, `queryParam`, etc.) in a file input (body or callback file path). 

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [x] CLI tests added (@mockoon/cli)
- [x] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed Docker and Docker Compose usage examples with updated container mount paths and proper configuration guidance.

* **Bug Fixes**
  * Enhanced path safety validation to prevent directory traversal attacks when using templated file paths in file serving operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->