### PR TITLE
fix: prevent ERR_HTTP_HEADERS_SENT crash in serverless (#2080)

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -2166,6 +2166,14 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     errorMessage: string | Error,
     status?: number
   ) {
+    // Headers may already be sent (e.g. in serverless environments where a
+    // delayed latency callback fires on an already-completed response). Trying
+    // to set headers or send again would throw ERR_HTTP_HEADERS_SENT and crash
+    // the process, so we bail out early. See issue #2080.
+    if (response.headersSent) {
+      return;
+    }
+
     response.set('Content-Type', 'text/plain');
     response.body = errorMessage;
 

--- a/packages/commons-server/test/specs/server/send-error-headers-sent.test.ts
+++ b/packages/commons-server/test/specs/server/send-error-headers-sent.test.ts
@@ -1,0 +1,78 @@
+import { Environment } from '@mockoon/commons';
+import { doesNotThrow, strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+import { MockoonServer } from '../../../src';
+import { getEnvironment } from '../../libs/environment';
+
+/**
+ * Regression test for issue #2080:
+ * In serverless environments (e.g. AWS Lambda), a delayed latency callback can
+ * fire on a response whose headers have already been sent. When the body could
+ * not be served, `sendError` was called and tried to set headers / send again,
+ * throwing ERR_HTTP_HEADERS_SENT and crashing the handler.
+ *
+ * `sendError` must bail out early when `response.headersSent` is true.
+ */
+describe('sendError with already-sent response (issue #2080)', () => {
+  // Minimal Express-like response stub tracking mutating calls.
+  const buildResponseStub = (headersSent: boolean) => {
+    const calls: string[] = [];
+
+    return {
+      headersSent,
+      set: () => {
+        calls.push('set');
+
+        return undefined;
+      },
+      status: () => {
+        calls.push('status');
+
+        return undefined;
+      },
+      send: () => {
+        calls.push('send');
+
+        return undefined;
+      },
+      get calls() {
+        return calls;
+      }
+    };
+  };
+
+  let environment: Environment;
+
+  it('should not throw and should not mutate when headers are already sent', async () => {
+    environment = await getEnvironment('test');
+    const server = new MockoonServer(environment) as unknown as {
+      sendError: (response: unknown, message: string, status?: number) => void;
+    };
+
+    const response = buildResponseStub(true);
+
+    doesNotThrow(() => {
+      server.sendError(response, 'Some error', 500);
+    });
+
+    strictEqual(response.calls.length, 0);
+  });
+
+  it('should still send the error normally when headers are not yet sent', async () => {
+    environment = await getEnvironment('test');
+    const server = new MockoonServer(environment) as unknown as {
+      sendError: (response: unknown, message: string, status?: number) => void;
+    };
+
+    const response = buildResponseStub(false);
+
+    doesNotThrow(() => {
+      server.sendError(response, 'Some error', 500);
+    });
+
+    // Content-Type set, status set, body sent.
+    strictEqual(response.calls.includes('set'), true);
+    strictEqual(response.calls.includes('status'), true);
+    strictEqual(response.calls.includes('send'), true);
+  });
+});


### PR DESCRIPTION
Closes #2080

## The bug

On AWS Lambda (via `serverless-http`), `@mockoon/serverless` 9.4.0+ crashes with `ERR_HTTP_HEADERS_SENT`, returning 404 most of the time:

```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at MockoonServer.sendError (.../server.js:1359)
    at MockoonServer.serveBody (.../server.js:954)
    at Timeout._onTimeout (.../server.js:838)
```

## Root cause

A response is served from inside a `setTimeout` latency callback. In a reused Lambda container, the event loop can interleave requests — a deferred timer callback fires on a response whose headers have **already been committed** by `serverless-http`. The crash path is:

1. `serveBody` calls `response.send()` → throws `ERR_HTTP_HEADERS_SENT`.
2. The `catch` block calls `sendError`.
3. `sendError` **again** calls `response.set()` / `response.send()` → throws `ERR_HTTP_HEADERS_SENT` a second time.
4. That second throw is inside a timer callback → **unhandled** → crashes the Lambda handler.

## Local reproduction (no Lambda required)

The bug is fully reproducible locally using `serverless-http`'s mock API Gateway event, which exercises the exact same code path as Lambda:

```
@mockoon/serverless 9.4.0 — 20 sequential requests via awsHandler()

Results (BUGGY):
  Successful (200):  12
  Errors (404):       8
  Uncaught exceptions: 8 × "Cannot set headers after they are sent to the client"

Stack trace matches the issue exactly:
  at MockoonServer.sendError (.../commons-server/.../server.js:1359)
  at MockoonServer.serveBody (.../commons-server/.../server.js:954)
  at Timeout._onTimeout (.../commons-server/.../server.js:838)
```

## The fix

Guard `sendError` with an early return when the response is already committed:

```ts
private sendError(response, errorMessage, status?) {
  if (response.headersSent) {
    return;
  }
  // ...unchanged
}
```

When `headersSent` is true there is nothing left to do — the client has already received a response — so `sendError` returns instead of throwing.

## Result (with fix applied)

```
Results (FIXED):
  Successful (200):  10
  Errors (404):      10
  Uncaught exceptions: 0 ✓
```

The unhandled second throw is gone — the Lambda handler no longer crashes. The underlying race condition (timer firing on an already-committed response) is an inherent characteristic of the `serverless-http` + `setTimeout` latency design; the 404s from that path are a separate concern. The reported crash is fixed.

## Why this approach (and not the alternatives)

- **Guard in `sendError` (chosen):** `sendError` is the single terminal point for every error path (route serving, file serving, range errors, proxy errors, global error handler). `headersSent` is Node's canonical signal that the response is committed, so one check here protects every caller with no behavior change for the normal case. Minimal and low-risk: +8 lines. Also aligns with [Express's own error-handling guidance](https://expressjs.com/en/guide/error-handling.html) which recommends checking `res.headersSent` in the error handler.
- **Guard at the start of the latency `setTimeout` callback:** covers only that one path; `sendError` can still crash from other callers (file serving, proxy). The chosen guard is strictly more general.
- **Removing/redesigning the deferred latency send:** much larger change, touches core serving and the latency feature unnecessarily.
- **try/catch around every `response.send`:** scatters defensive code across many call sites and still leaves `sendError` able to crash; the single guard subsumes all of them.

## Tests

Added `send-error-headers-sent.test.ts`:
- `headersSent: true` → `sendError` does not throw and performs no response mutation.
- `headersSent: false` → error is still sent normally (Content-Type, status, body).

Verified locally (built libs + serverless first, per CONTRIBUTING.md):
- `npm run test:commons-server` → 800 passed, 0 failed.
- `npm run test:serverless` → 3 passed, 0 failed.
- ESLint and Prettier clean on the changed files.