### PR TITLE
Fix serverless lib returning a 404 when no body is present

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -635,7 +635,12 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         rawBody.push(Buffer.from(chunk, 'binary'));
       });
 
-      request.on('end', () => {
+      // Use `once` to guarantee the body is processed and `next()` is called a
+      // single time. Some environments (e.g. serverless-http used by the
+      // serverless package) emit the request 'end' event more than once, which
+      // would otherwise dispatch the whole routing pipeline twice and lead to a
+      // double response send (ERR_HTTP_HEADERS_SENT).
+      request.once('end', () => {
         this.processRawBody(request, next, rawBody, requestContentType);
       });
     }

--- a/packages/commons-server/test/specs/server/server-body-parsing.test.ts
+++ b/packages/commons-server/test/specs/server/server-body-parsing.test.ts
@@ -1,5 +1,6 @@
 import { BodyTypes, Environment, RouteType } from '@mockoon/commons';
-import { deepEqual } from 'node:assert';
+import { deepEqual, strictEqual } from 'node:assert';
+import { EventEmitter } from 'node:events';
 import { after, before, describe, it } from 'node:test';
 import { MockoonServer } from '../../../src';
 
@@ -159,4 +160,34 @@ describe('Server body parsing', () => {
       server.stop();
     });
   });
+
+  describe('Duplicate request end events', () => {
+    it('should only advance the routing pipeline once when end is emitted twice', () => {
+      const server = new MockoonServer(environment);
+      let nextCalls = 0;
+
+      const request = new EventEmitter() as RequestLike;
+      request.headers = {};
+      request.header = () => undefined;
+
+      (server as any).parseBody(request, {} as any, () => {
+        nextCalls += 1;
+      });
+
+      request.emit('end');
+      request.emit('end');
+
+      strictEqual(nextCalls, 1);
+      strictEqual(request.stringBody, '');
+      strictEqual(request.rawBody?.toString('utf8'), '');
+    });
+  });
 });
+
+type RequestLike = EventEmitter & {
+  headers: Record<string, string>;
+  rawBody?: Buffer;
+  stringBody?: string;
+  body?: unknown;
+  header(name: string): string | undefined;
+};


### PR DESCRIPTION
serverless-http can trigger the "end" event twice.

Closes #2080

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [x] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request body parsing in serverless environments to avoid duplicate handling when the request signals completion more than once.
  * Prevented potential duplicate middleware progression and duplicate-response scenarios, reducing related request errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->