### PR TITLE
Add response flag on the dropdown menu

### DIFF
--- a/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.html
+++ b/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.html
@@ -11,12 +11,81 @@
 @let deleteCurrentRouteResponseRequested =
   deleteCurrentRouteResponseRequested$ | async;
 @let databuckets = databuckets$ | async;
-@let defaultResponseTooltip = defaultResponseTooltip$ | async;
 @let bodyEditorConfig = bodyEditorConfig$ | async;
 @let effectiveContentType = effectiveContentType$ | async;
 @let activeRouteResponseLastLog = activeRouteResponseLastLog$ | async;
 @let externalLink = externalLink$ | async;
 @let bodyType = bodyType$ | async;
+
+<ng-template
+  #defaultFlagTemplate
+  let-routeResponse="routeResponse"
+  let-interactable="interactable"
+>
+  @if (activeRoute?.type === 'crud' && routeResponse.default) {
+    <span
+      class="px-2 text-primary"
+      [ngbTooltip]="
+        interactable
+          ? 'Response linked to the data bucket for CRUD operations'
+          : undefined
+      "
+    >
+      <app-svg icon="data" />
+    </span>
+  }
+  @if (activeRoute?.type === 'http' || activeRoute?.type === 'ws') {
+    @if (interactable) {
+      <button
+        type="button"
+        class="btn btn-link btn-xs btn-icon px-2 py-0"
+        [disabled]="!isActiveEnvironmentEditable"
+        (click)="
+          setDefaultRouteResponse(
+            routeResponse.default ? null : routeResponse.uuid,
+            $event
+          )
+        "
+        [class]="{
+          'text-primary':
+            routeResponse.default &&
+            !rulesNotUsingDefaultResponse.includes(activeRoute?.responseMode),
+          'text-muted':
+            !routeResponse.default ||
+            rulesNotUsingDefaultResponse.includes(activeRoute?.responseMode)
+        }"
+        [ngbTooltip]="
+          routeResponse.default
+            ? (defaultResponseTooltips[activeRoute?.responseMode] ??
+              'Default response is served when no rule matches')
+            : 'Make route response as default'
+        "
+      >
+        <app-svg
+          [icon]="routeResponse.default ? 'flag' : 'outlined_flag'"
+          [attr.icon]="routeResponse.default ? 'flag' : 'outlined_flag'"
+        />
+      </button>
+    } @else {
+      <span
+        class="px-2 text-primary"
+        [class]="{
+          'text-primary': !rulesNotUsingDefaultResponse.includes(
+            activeRoute?.responseMode
+          ),
+          'text-muted':
+            !routeResponse.default ||
+            rulesNotUsingDefaultResponse.includes(activeRoute?.responseMode)
+        }"
+      >
+        <app-svg
+          [icon]="routeResponse.default ? 'flag' : 'outlined_flag'"
+          [attr.icon]="routeResponse.default ? 'flag' : 'outlined_flag'"
+        />
+      </span>
+    }
+  }
+</ng-template>
 
 <div class="d-flex h-100">
   <app-routes-menu class="h-100" />
@@ -189,8 +258,19 @@
                         )
                       "
                     ></div>
+
+                    <div class="d-flex align-items-center ms-auto">
+                      <ng-container
+                        [ngTemplateOutlet]="defaultFlagTemplate"
+                        [ngTemplateOutletContext]="{
+                          routeResponse: activeRouteResponse,
+                          interactable: false
+                        }"
+                      />
+                    </div>
+
                     <div
-                      class="d-flex align-items-center badge badge-hollow fw-bold ms-auto"
+                      class="d-flex align-items-center badge badge-hollow fw-bold"
                     >
                       {{ activeRoute?.responses.length }}
                     </div>
@@ -260,54 +340,14 @@
                       "
                     >
                     </span>
-                    @if (
-                      activeRoute?.type === 'crud' && routeResponse.default
-                    ) {
-                      <span
-                        class="px-2 text-primary"
-                        ngbTooltip="Response linked to the data bucket for CRUD operations"
-                      >
-                        <app-svg icon="data" />
-                      </span>
-                    }
-                    @if (
-                      activeRoute?.type === 'http' || activeRoute?.type === 'ws'
-                    ) {
-                      @if (routeResponse.default) {
-                        <button
-                          type="button"
-                          class="btn btn-link btn-xs btn-icon px-2 py-0"
-                          [disabled]="!isActiveEnvironmentEditable"
-                          (click)="setDefaultRouteResponse(null, $event)"
-                          [class.text-primary]="
-                            !rulesNotUsingDefaultResponse.includes(
-                              activeRoute?.responseMode
-                            )
-                          "
-                          [class.text-muted]="
-                            rulesNotUsingDefaultResponse.includes(
-                              activeRoute?.responseMode
-                            )
-                          "
-                          [ngbTooltip]="defaultResponseTooltip"
-                        >
-                          <app-svg icon="flag" />
-                        </button>
-                      }
-                      @if (!routeResponse.default) {
-                        <button
-                          type="button"
-                          class="btn btn-link btn-xs btn-icon text-muted px-2 py-0"
-                          [disabled]="!isActiveEnvironmentEditable"
-                          (click)="
-                            setDefaultRouteResponse(routeResponse.uuid, $event)
-                          "
-                          ngbTooltip="Make route response as default"
-                        >
-                          <app-svg icon="outlined_flag" />
-                        </button>
-                      }
-                    }
+
+                    <ng-container
+                      [ngTemplateOutlet]="defaultFlagTemplate"
+                      [ngTemplateOutletContext]="{
+                        routeResponse,
+                        interactable: true
+                      }"
+                    />
                   </div>
                 }
               </div>

--- a/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.ts
+++ b/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -132,7 +132,8 @@ type fileDropdownMenuPayload = { filePath: string; environmentUuid: string };
     HeadersListComponent,
     RouteResponseRulesComponent,
     RouteCallbacksComponent,
-    AsyncPipe
+    AsyncPipe,
+    NgTemplateOutlet
   ]
 })
 export class EnvironmentRoutesComponent {
@@ -157,7 +158,6 @@ export class EnvironmentRoutesComponent {
   }>;
   public buildResponseLabel = buildResponseLabel;
   public effectiveContentType$: Observable<string>;
-  public defaultResponseTooltip$: Observable<string>;
   public routeHasErrors$: Observable<string>;
   public environmentsStatus$: Observable<EnvironmentsStatuses>;
   public activeTab$: Observable<TabsNameType>;
@@ -168,6 +168,14 @@ export class EnvironmentRoutesComponent {
   public scrollToBottom = this.uiService.scrollToBottom;
   public databuckets$: Observable<DropdownItems>;
   public externalLink$: Observable<string>;
+  public defaultResponseTooltips = {
+    [ResponseMode.RANDOM]: 'Default response is disabled in random mode',
+    [ResponseMode.SEQUENTIAL]:
+      'Default response is disabled in sequential mode',
+    [ResponseMode.DISABLE_RULES]:
+      'Default response is always served because rules are disabled',
+    [ResponseMode.FALLBACK]: 'Default response is disabled in fallback mode'
+  };
   public methods: DropdownItems = [
     {
       value: Methods.all,
@@ -249,24 +257,24 @@ export class EnvironmentRoutesComponent {
     {
       value: ResponseMode.RANDOM,
       icon: 'shuffle',
-      tooltip: 'Random response mode (will disable the rules)'
+      tooltip: 'Random response mode (rules are ignored)'
     },
     {
       value: ResponseMode.SEQUENTIAL,
       icon: 'repeat',
-      tooltip: 'Sequential response mode (will disable the rules)'
+      tooltip: 'Sequential response mode (rules are ignored)'
     },
     {
       value: ResponseMode.DISABLE_RULES,
       icon: 'rule',
-      tooltip: 'Disabled rules mode (default response only)',
+      tooltip: 'Rules disabled mode (default response only)',
       activeClass: 'text-warning'
     },
     {
       value: ResponseMode.FALLBACK,
       icon: 'low_priority',
       tooltip:
-        'Fallback response mode (does not return the default response if none of the rules match, will jump to the next route or use the proxy if configured)'
+        'Fallback response mode (if no rule matches, this route is skipped and Mockoon tries the next route or proxy if configured)'
     }
   ];
   // disables fallback mode for websockets.
@@ -508,23 +516,6 @@ export class EnvironmentRoutesComponent {
     this.environmentsStatus$ = this.store.select('environmentsStatus');
     this.activeTab$ = this.store.select('activeTab');
     this.bodyEditorConfig$ = this.store.select('bodyEditorConfig');
-
-    this.defaultResponseTooltip$ = this.activeRoute$.pipe(
-      filter((activeRoute) => !!activeRoute),
-      distinctUntilChanged(),
-      map((activeRoute) => {
-        if (
-          activeRoute.responseMode === ResponseMode.SEQUENTIAL ||
-          activeRoute.responseMode === ResponseMode.RANDOM
-        ) {
-          return 'Default response disabled by random or sequential responses';
-        } else if (activeRoute.responseMode === ResponseMode.DISABLE_RULES) {
-          return 'Default response always served as rules are disabled';
-        }
-
-        return 'Default response served if no rule matches';
-      })
-    );
 
     this.routeHasErrors$ = this.activeRoute$.pipe(
       filter((activeRoute) => !!activeRoute),


### PR DESCRIPTION
Closes #1792

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified the “default response” flag rendering across CRUD and HTTP/WS route response menus.
* **UX Improvements**
  * Updated the dropdown indicator behavior: non-interactive default indicators vs clickable selectable items, with consistent tooltip display.
  * Refreshed response-mode tooltip wording for clearer guidance.
* **Bug Fixes**
  * Preserved default-setting behavior so selecting “default” continues to apply the prior default action for HTTP/WS routes.
* **Tests**
  * Adjusted route-response UI selectors to match the updated flag markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->