### PR TITLE
Fix too strict path traversal protection

### DIFF
--- a/packages/cli/test/data/envs/file.json
+++ b/packages/cli/test/data/envs/file.json
@@ -99,6 +99,37 @@
       "type": "http",
       "streamingMode": null,
       "streamingInterval": 0
+    },
+    {
+      "uuid": "7f0b6d16-6b0a-4a8f-96f7-6b3d1b1a2a52",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "testfile/:route",
+      "responses": [
+        {
+          "uuid": "a3e6bb04-6d13-4a1a-9a1e-2f0f6a0b6a11",
+          "body": "",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "filePath": "./file{{urlParam 'route'}}.json",
+          "sendFileAsBody": true,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "databucketID": "",
+          "bodyType": "FILE",
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "type": "http",
+      "streamingMode": null,
+      "streamingInterval": 0
     }
   ],
   "proxyMode": false,
@@ -122,7 +153,8 @@
   "rootChildren": [
     { "type": "route", "uuid": "e15f2c20-92aa-4390-8f83-2da2473b47ee" },
     { "type": "route", "uuid": "8663d5f8-fe76-46a9-baca-437524edf763" },
-    { "type": "route", "uuid": "b0cd35cf-d6e6-4d6c-be4f-309af6d4e12a" }
+    { "type": "route", "uuid": "b0cd35cf-d6e6-4d6c-be4f-309af6d4e12a" },
+    { "type": "route", "uuid": "7f0b6d16-6b0a-4a8f-96f7-6b3d1b1a2a52" }
   ],
   "callbacks": []
 }

--- a/packages/cli/test/data/envs/file1.json
+++ b/packages/cli/test/data/envs/file1.json
@@ -1,0 +1,1 @@
+filecontent

--- a/packages/cli/test/data/envs/file2.json
+++ b/packages/cli/test/data/envs/file2.json
@@ -1,0 +1,1 @@
+filecontent2

--- a/packages/cli/test/specs/file-serving.test.ts
+++ b/packages/cli/test/specs/file-serving.test.ts
@@ -50,4 +50,20 @@ describe('File serving', () => {
 
     ok(responseBody.includes('filecontent'));
   });
+
+  it('should get a partially templated file when the helper is in the middle of the file name', async () => {
+    const { instance } = await spawnCli([
+      'start',
+      '--data',
+      './test/data/envs/file.json'
+    ]);
+
+    const responseBody = await (
+      await fetch('http://localhost:3000/testfile/1')
+    ).text();
+
+    instance.kill();
+
+    ok(responseBody.includes('filecontent'));
+  });
 });

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -2385,7 +2385,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
    * Parse file paths and prevent path traversal
    *
    * If the path is absolute, it must stay within its original static base
-   * (before the first {{...}})
+   * directory (last folder separator before the first {{...}})
    * If the path is relative, it must stay within the environment base directory
    *
    * @param filePath
@@ -2419,8 +2419,8 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       return resolvePath(rawFilePath);
     }
 
-    // Extract static base from templated string (before first {{...}})
-    const staticBaseMatch = rawFilePath.match(/^([^{}]+)/);
+    // Extract static base directory from templated string (last folder separator before the first {{...}})
+    const staticBaseMatch = rawFilePath.match(/^([^{}]*\/)/);
     const staticBaseDir = staticBaseMatch?.[1]
       ? resolvePath(staticBaseMatch[1])
       : null;

--- a/packages/commons-server/test/specs/server/server-file-serving.test.ts
+++ b/packages/commons-server/test/specs/server/server-file-serving.test.ts
@@ -249,5 +249,53 @@ describe('Server file serving', () => {
         )
       );
     });
+
+    it('should allow templated relative paths when the helper is in the middle of the file name', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathResolve('./test/data')
+      });
+
+      equal(
+        callGetSafeFilePath(
+          server,
+          `./static/file{{queryParam 'name'}}.json`,
+          buildRequest({ name: '1' })
+        ),
+        pathResolve('./test/data', 'static/file1.json')
+      );
+    });
+
+    it('should allow an absolute partially templated file path', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathResolve('./test/data')
+      });
+      const publicDir = pathResolve('./test/data/public');
+
+      equal(
+        callGetSafeFilePath(
+          server,
+          `${publicDir}\\file{{queryParam 'name'}}.json`,
+          buildRequest({ name: '1' })
+        ),
+        pathResolve(publicDir, 'file1.json')
+      );
+    });
+
+    it('should block templated paths escaping the static base when the helper is in the middle of the file name', () => {
+      const server = new MockoonServer(environment, {
+        environmentDirectory: pathResolve('./test/data')
+      });
+      const publicDir = pathResolve('./test/data/public');
+
+      throws(
+        () =>
+          callGetSafeFilePath(
+            server,
+            `${publicDir}/file{{queryParam 'name'}}.json`,
+            buildRequest({ name: '/../../secret' })
+          ),
+        /outside of the original static base directory/
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #2319

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serving of files with templates embedded in their filenames, including templates placed within filenames.
  * Preserved static-directory restrictions for templated paths, including attempts to access files outside the allowed directory and paths using different separators.

* **Tests**
  * Added coverage for partially templated filenames, cross-platform path separators, and directory traversal protection.
  * Added CLI test fixtures validating templated file responses and dynamic file selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->