### PR TITLE
Ignore requests with HTTP/2 upgrade headers

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -46,14 +46,18 @@ import { EventEmitter } from 'events';
 import express, { Application, NextFunction, Request, Response } from 'express';
 import { createReadStream, readFile, readFileSync, statSync } from 'fs';
 import type { RequestListener } from 'http';
-import { createServer as httpCreateServer, Server as httpServer } from 'http';
+import {
+  IncomingMessage,
+  createServer as httpCreateServer,
+  Server as httpServer
+} from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import {
   createServer as httpsCreateServer,
   Server as httpsServer
 } from 'https';
 import killable from 'killable';
-import { AddressInfo, isIPv6 } from 'node:net';
+import { AddressInfo, Socket, isIPv6 } from 'node:net';
 import { basename, extname, isAbsolute, parse, relative, resolve } from 'path';
 import { parse as qsParse } from 'qs';
 import rangeParser from 'range-parser';
@@ -95,6 +99,31 @@ import {
   messageToString,
   serveFileContentInWs
 } from './ws';
+
+/**
+ * Node's HTTP server hands over *any* request containing an "Upgrade" header
+ * (h2c, TLS, etc.) to the 'upgrade' event as soon as a listener is registered,
+ * and such requests can then no longer be handled as regular ones.
+ * Reporting the upgrade flag only for WebSocket requests keeps the other
+ * upgrade requests on the normal request path.
+ * See https://github.com/nodejs/node/issues/6339
+ */
+class WebSocketOnlyIncomingMessage extends IncomingMessage {
+  constructor(socket: Socket) {
+    super(socket);
+
+    Object.defineProperty(this, 'upgrade', {
+      configurable: true,
+      get: () =>
+        this.method === 'CONNECT' ||
+        (this.headers.upgrade?.toLowerCase() === 'websocket' &&
+          !!this.headers.connection?.toLowerCase().includes('upgrade')),
+      // ignore the value set by Node's HTTP parser
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      set: () => {}
+    });
+  }
+}
 
 /**
  * Create a server instance from an Environment object.
@@ -184,7 +213,10 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       try {
         this.tlsOptions = this.buildTLSOptions(this.environment);
 
-        this.serverInstance = httpsCreateServer(this.tlsOptions);
+        this.serverInstance = httpsCreateServer({
+          ...this.tlsOptions,
+          IncomingMessage: WebSocketOnlyIncomingMessage
+        });
       } catch (error: any) {
         if (error.code === 'ENOENT') {
           this.emit('error', ServerErrorCodes.CERT_FILE_NOT_FOUND, error);
@@ -193,7 +225,9 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         }
       }
     } else {
-      this.serverInstance = httpCreateServer();
+      this.serverInstance = httpCreateServer({
+        IncomingMessage: WebSocketOnlyIncomingMessage
+      });
     }
 
     // make serverInstance killable
@@ -959,7 +993,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     const urlParsed = parseUrl(req.url || '', true);
 
     // check if the request is a websocket upgrade request
-    if (req.headers.upgrade !== 'websocket') {
+    if (req.headers.upgrade?.toLowerCase() !== 'websocket') {
       socket.write(`HTTP/${req.httpVersion} 400 Bad Request\r\n`);
       socket.write('Content-Type: text/html\r\n');
       socket.write('Content-length: 72\r\n\r\n');

--- a/packages/commons-server/test/specs/server/server-upgrade.test.ts
+++ b/packages/commons-server/test/specs/server/server-upgrade.test.ts
@@ -1,0 +1,177 @@
+import { BodyTypes, Environment, RouteType } from '@mockoon/commons';
+import { match, strictEqual } from 'node:assert';
+import { connect } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+import { WebSocket } from 'ws';
+import { MockoonServer } from '../../../src';
+
+const port = 3012;
+
+const environment: Environment = {
+  uuid: '0f8a2f2a-0d1a-4b31-9b5a-2f3b6e5a1c11',
+  lastMigration: 32,
+  name: 'Test env',
+  port,
+  hostname: '',
+  endpointPrefix: '',
+  latency: 0,
+  routes: [
+    {
+      uuid: 'a1b3f0f1-2c62-4b2d-9c8f-1a2b3c4d5e6f',
+      documentation: '',
+      method: 'get',
+      endpoint: 'test',
+      responses: [
+        {
+          uuid: 'b2c4e1f2-3d73-4c3e-8d9f-2b3c4d5e6f70',
+          rules: [],
+          rulesOperator: 'OR',
+          statusCode: 200,
+          label: '',
+          headers: [],
+          latency: 0,
+          filePath: '',
+          sendFileAsBody: false,
+          disableTemplating: false,
+          fallbackTo404: false,
+          body: 'http response',
+          default: true,
+          databucketID: '',
+          bodyType: BodyTypes.INLINE,
+          crudKey: 'id',
+          callbacks: []
+        }
+      ],
+      responseMode: null,
+      type: RouteType.HTTP,
+      streamingInterval: 0,
+      streamingMode: null
+    },
+    {
+      uuid: 'c3d5f2f3-4e84-4d4f-9eaf-3c4d5e6f7081',
+      documentation: '',
+      method: 'get',
+      endpoint: 'ws',
+      responses: [
+        {
+          uuid: 'd4e6f3f4-5f95-4e50-afbf-4d5e6f708192',
+          rules: [],
+          rulesOperator: 'OR',
+          statusCode: 200,
+          label: '',
+          headers: [],
+          latency: 0,
+          filePath: '',
+          sendFileAsBody: false,
+          disableTemplating: false,
+          fallbackTo404: false,
+          body: 'ws response',
+          default: true,
+          databucketID: '',
+          bodyType: BodyTypes.INLINE,
+          crudKey: 'id',
+          callbacks: []
+        }
+      ],
+      responseMode: null,
+      type: RouteType.WS,
+      streamingInterval: 0,
+      streamingMode: null
+    }
+  ],
+  proxyMode: false,
+  proxyRemovePrefix: false,
+  proxyHost: '',
+  proxyReqHeaders: [],
+  proxyResHeaders: [],
+  cors: false,
+  headers: [],
+  tlsOptions: {
+    enabled: false,
+    type: 'CERT',
+    pfxPath: '',
+    certPath: '',
+    keyPath: '',
+    caPath: '',
+    passphrase: ''
+  },
+  data: [],
+  folders: [],
+  rootChildren: [
+    { type: 'route', uuid: 'a1b3f0f1-2c62-4b2d-9c8f-1a2b3c4d5e6f' },
+    { type: 'route', uuid: 'c3d5f2f3-4e84-4d4f-9eaf-3c4d5e6f7081' }
+  ],
+  callbacks: []
+};
+
+/**
+ * Send a raw HTTP request (fetch cannot send "Connection" and "Upgrade" headers)
+ * and return the raw response.
+ */
+const sendRawRequest = (request: string) =>
+  new Promise<string>((resolve, reject) => {
+    const socket = connect(port, '127.0.0.1', () => {
+      socket.write(request);
+    });
+    socket.setTimeout(2000);
+    socket.on('data', (data) => {
+      socket.destroy();
+      resolve(data.toString());
+    });
+    socket.on('timeout', () => {
+      socket.destroy();
+      reject(new Error('No response received'));
+    });
+    socket.on('error', reject);
+  });
+
+describe('Server connection upgrade', () => {
+  let server: MockoonServer;
+
+  before((_context, done) => {
+    server = new MockoonServer(environment);
+    server.on('error', () => {
+      // empty
+    });
+    server.on('started', () => {
+      done();
+    });
+
+    server.start();
+  });
+
+  it('should handle a non-WebSocket upgrade request (HTTP/2) as a regular request', async () => {
+    const response = await sendRawRequest(
+      'GET /test HTTP/1.1\r\n' +
+        `Host: localhost:${port}\r\n` +
+        'Connection: Upgrade, HTTP2-Settings\r\n' +
+        'Upgrade: HTTP/2.0\r\n' +
+        'HTTP2-Settings: AAEAABAAAAIAAAABAAN_____AAQAAP__AAUAAEAAAAYAACAA\r\n' +
+        '\r\n'
+    );
+
+    match(response, /^HTTP\/1\.1 200 OK/);
+    match(response, /http response$/);
+  });
+
+  it('should still handle WebSocket upgrade requests', async () => {
+    const message = await new Promise<string>((resolve, reject) => {
+      const client = new WebSocket(`ws://localhost:${port}/ws`);
+
+      client.on('open', () => {
+        client.send('hello');
+      });
+      client.on('message', (data) => {
+        client.close();
+        resolve(data.toString());
+      });
+      client.on('error', reject);
+    });
+
+    strictEqual(message, 'ws response');
+  });
+
+  after(() => {
+    server.stop();
+  });
+});


### PR DESCRIPTION
Closes #1908

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of connection upgrade requests so HTTP/2-style upgrades continue to regular HTTP routes.
  * Preserved WebSocket upgrade behavior for genuine WebSocket connections.
  * WebSocket upgrade header validation now works regardless of header capitalization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->