### PR TITLE
Detect template used to generate crud ID and reuse it

### DIFF
--- a/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.html
+++ b/packages/app/src/renderer/app/components/environment-routes/environment-routes.component.html
@@ -547,6 +547,7 @@
                         class="form-control"
                         formControlName="crudKey"
                         placeholder="id property for crud operations ('id', 'uuid', 'data.id', etc.)"
+                        ngbTooltip="Id property used for CRUD operations ('id', 'uuid', 'data.id', etc.). New items reuse the templating expression used for this property in the data bucket."
                       />
                     </div>
                   }

--- a/packages/commons-server/src/libs/server/crud.ts
+++ b/packages/commons-server/src/libs/server/crud.ts
@@ -11,6 +11,129 @@ import { convertPathToArray, fullTextSearch } from '../utils';
 
 export const crudRouteParamName = 'id';
 
+const templatingExpressionPattern =
+  '(?:\\{\\{\\{[\\s\\S]*?\\}\\}\\}|\\{\\{[\\s\\S]*?\\}\\})';
+
+/**
+ * Extract, from the raw (unparsed) databucket template, the templating expression
+ * used to generate the value of the CRUD key (e.g. `"id": "{{faker 'location.country'}}"`)
+ *
+ * @param databucketTemplate
+ * @param crudKey
+ * @returns
+ */
+export const extractIdTemplate = (
+  databucketTemplate: string,
+  crudKey: string
+): string | null => {
+  const pathSegments = convertPathToArray(crudKey);
+  const keyParts = Array.isArray(pathSegments)
+    ? pathSegments
+    : pathSegments.split('.');
+  const expressionMatcher = new RegExp(templatingExpressionPattern, 'g');
+  const structureTemplate = databucketTemplate.replace(
+    expressionMatcher,
+    (expression) => ' '.repeat(expression.length)
+  );
+  const tokenMatcher = /\{|\}|["']?([A-Za-z_$][\w$]*)["']?\s*:/g;
+  const objectPaths: string[][] = [];
+  let pendingPath: string[] | null = null;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenMatcher.exec(structureTemplate))) {
+    if (match[0] === '{') {
+      objectPaths.push(
+        pendingPath ?? objectPaths[objectPaths.length - 1] ?? []
+      );
+      pendingPath = null;
+    } else if (match[0] === '}') {
+      objectPaths.pop();
+      pendingPath = null;
+    } else {
+      const propertyPath = [
+        ...(objectPaths[objectPaths.length - 1] ?? []),
+        match[1]
+      ];
+      const idMatch = new RegExp(
+        `^\\s*"?(${templatingExpressionPattern}+)"?`
+      ).exec(databucketTemplate.slice(match.index + match[0].length));
+
+      if (idMatch && propertyPath.join('.') === keyParts.join('.')) {
+        return idMatch[1];
+      }
+
+      pendingPath = propertyPath;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Convert a generated id back to a number when it can be safely represented as one
+ *
+ * @param generatedId
+ * @returns
+ */
+const castGeneratedId = (generatedId: string): string | number => {
+  const trimmedId = generatedId.trim();
+
+  if (trimmedId === '') {
+    return '';
+  }
+
+  return String(Number(trimmedId)) === trimmedId
+    ? Number(trimmedId)
+    : trimmedId;
+};
+
+/**
+ * Generate the id of a new item from the templating expression used for the key
+ * in the databucket template, or by incrementing the highest numeric id present
+ * in the databucket (falling back to a random UUID)
+ *
+ * @param databucketValue
+ * @param crudKey
+ * @param templateParse
+ * @param databucketTemplate
+ * @returns
+ */
+const generateItemId = (
+  databucketValue: any[],
+  crudKey: string,
+  templateParse?: (content: string) => string,
+  databucketTemplate?: string
+): string | number => {
+  const idTemplate = databucketTemplate
+    ? extractIdTemplate(databucketTemplate, crudKey)
+    : null;
+
+  if (idTemplate && templateParse) {
+    try {
+      const generatedId = castGeneratedId(templateParse(idTemplate));
+
+      if (generatedId !== '') {
+        return generatedId;
+      }
+    } catch (_error) {
+      // fall back to the default id generation
+    }
+  }
+
+  // get highest id in the array
+  const highestId = databucketValue.reduce<number | null>((maxId, item) => {
+    const itemId = getPath(item, convertPathToArray(crudKey));
+
+    if (typeof itemId === 'number' && (maxId === null || itemId > maxId)) {
+      return itemId;
+    }
+
+    return maxId;
+  }, null);
+
+  return highestId !== null ? highestId + 1 : generateUUID();
+};
+
 /**
  * Find an item by its id in an array of objects or by its index in an array of primitives
  *
@@ -46,11 +169,15 @@ export const databucketActions = (
   databucket: ProcessedDatabucket,
   request: Request,
   response: Response,
-  routeCrudKey: RouteResponse['crudKey']
+  routeCrudKey: RouteResponse['crudKey'],
+  templateParse?: (content: string) => string,
+  databucketTemplate?: string
 ): any => {
   if (databucket.parsed) {
     response.set('Content-Type', 'application/json');
   }
+
+  const crudKey = routeCrudKey;
 
   const requestBody =
     request.body !== undefined ? request.body : request.stringBody || {};
@@ -130,11 +257,7 @@ export const databucketActions = (
 
     case 'getbyId': {
       if (Array.isArray(databucket.value)) {
-        const foundIndex = findItemIndex(
-          databucket.value,
-          request,
-          routeCrudKey
-        );
+        const foundIndex = findItemIndex(databucket.value, request, crudKey);
 
         if (foundIndex !== -1) {
           responseBody = databucket.value[foundIndex];
@@ -153,23 +276,17 @@ export const databucketActions = (
         if (
           typeof requestBody === 'object' &&
           requestBody != null &&
-          getPath(requestBody, convertPathToArray(routeCrudKey)) === undefined
+          getPath(requestBody, convertPathToArray(crudKey)) === undefined
         ) {
-          // get highest id in the array
-          const highestId = databucket.value.reduce((maxId, item) => {
-            const itemId = getPath(item, convertPathToArray(routeCrudKey));
-
-            if (typeof itemId === 'number' && itemId > maxId) {
-              return itemId;
-            }
-
-            return maxId;
-          }, null);
-
           setPath(
             requestBody,
-            convertPathToArray(routeCrudKey),
-            highestId !== null ? highestId + 1 : generateUUID()
+            convertPathToArray(crudKey),
+            generateItemId(
+              databucket.value,
+              crudKey,
+              templateParse,
+              databucketTemplate
+            )
           );
         }
 
@@ -193,11 +310,7 @@ export const databucketActions = (
 
     case 'updateById': {
       if (Array.isArray(databucket.value)) {
-        const indexToModify = findItemIndex(
-          databucket.value,
-          request,
-          routeCrudKey
-        );
+        const indexToModify = findItemIndex(databucket.value, request, crudKey);
 
         if (indexToModify !== -1) {
           if (
@@ -206,7 +319,7 @@ export const databucketActions = (
           ) {
             const currentItemId = getPath(
               databucket.value[indexToModify],
-              convertPathToArray(routeCrudKey)
+              convertPathToArray(crudKey)
             );
 
             databucket.value[indexToModify] = {
@@ -217,12 +330,11 @@ export const databucketActions = (
 
             // restore the id if it was not provided in the request body
             if (
-              getPath(requestBody, convertPathToArray(routeCrudKey)) ===
-              undefined
+              getPath(requestBody, convertPathToArray(crudKey)) === undefined
             ) {
               setPath(
                 databucket.value[indexToModify],
-                convertPathToArray(routeCrudKey),
+                convertPathToArray(crudKey),
                 currentItemId
               );
             }
@@ -269,11 +381,7 @@ export const databucketActions = (
 
     case 'updateMergeById': {
       if (Array.isArray(databucket.value)) {
-        const indexToModify = findItemIndex(
-          databucket.value,
-          request,
-          routeCrudKey
-        );
+        const indexToModify = findItemIndex(databucket.value, request, crudKey);
 
         if (indexToModify !== -1) {
           databucket.value[indexToModify] =
@@ -318,11 +426,7 @@ export const databucketActions = (
 
     case 'deleteById': {
       if (Array.isArray(databucket.value)) {
-        const indexToDelete = findItemIndex(
-          databucket.value,
-          request,
-          routeCrudKey
-        );
+        const indexToDelete = findItemIndex(databucket.value, request, crudKey);
 
         if (indexToDelete === -1) {
           response.status(404);

--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1537,7 +1537,21 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
                 servedDatabucket,
                 request,
                 response,
-                route.responses[0].crudKey
+                route.responses[0].crudKey,
+                (idTemplate) =>
+                  TemplateParser({
+                    shouldOmitDataHelper: false,
+                    content: idTemplate,
+                    environment: this.environment,
+                    processedDatabuckets: this.processedDatabuckets,
+                    globalVariables: this.globalVariables,
+                    request: fromExpressRequest(request),
+                    envVarsPrefix: this.options.envVarsPrefix,
+                    publicBaseUrl: this.options.publicBaseUrl
+                  }),
+                this.environment.data.find(
+                  (databucket) => databucket.uuid === servedDatabucket.uuid
+                )?.value
               );
             }
 

--- a/packages/commons-server/test/specs/server/server-databucket-actions.test.ts
+++ b/packages/commons-server/test/specs/server/server-databucket-actions.test.ts
@@ -70,6 +70,114 @@ describe('Databucket Actions', () => {
     deepStrictEqual(databucket.value[0], request.body);
   });
 
+  it('should generate the id using the expression found in the databucket template', () => {
+    request.body = { name: 'John' };
+    routeCrudKey = 'id';
+
+    databucketActions(
+      'create',
+      databucket,
+      request,
+      response,
+      routeCrudKey,
+      (content) => (content === "{{faker 'location.country'}}" ? 'Panama' : ''),
+      '[{{#repeat 5}}{"id": "{{faker \'location.country\'}}", "name": "{{faker \'person.firstName\'}}"}{{/repeat}}]'
+    );
+
+    strictEqual(databucket.value[0].id, 'Panama');
+  });
+
+  it('should generate the id using an unquoted expression found in the databucket template', () => {
+    request.body = { name: 'John' };
+    routeCrudKey = 'id';
+
+    databucketActions(
+      'create',
+      databucket,
+      request,
+      response,
+      routeCrudKey,
+      (content) => (content === "{{faker 'number.int'}}" ? '25' : ''),
+      '[{"id": {{faker \'number.int\'}}}]'
+    );
+
+    strictEqual(databucket.value[0].id, 25);
+  });
+
+  it('should generate a nested id using its path-scoped expression', () => {
+    request.body = { name: 'John' };
+    routeCrudKey = 'data.id';
+
+    databucketActions(
+      'create',
+      databucket,
+      request,
+      response,
+      routeCrudKey,
+      (content) => (content === '{{nested}}' ? 'nested-id' : 'root-id'),
+      '[{"id": "{{root}}", "data": {"id": "{{nested}}"}}]'
+    );
+
+    strictEqual(databucket.value[0].data.id, 'nested-id');
+  });
+
+  it('should fall back to the default id generation if the databucket template has no expression for the key', () => {
+    databucket.value = [{ id: 5 }];
+    request.body = { name: 'John' };
+    routeCrudKey = 'id';
+
+    databucketActions(
+      'create',
+      databucket,
+      request,
+      response,
+      routeCrudKey,
+      () => 'should-not-be-used',
+      '[{"id": 5, "name": "{{faker \'person.firstName\'}}"}]'
+    );
+
+    strictEqual(databucket.value[1].id, 6);
+  });
+
+  it('should fall back to the default id generation if the templating expression fails', () => {
+    databucket.value = [{ id: 5 }];
+    request.body = { name: 'John' };
+    routeCrudKey = 'id';
+
+    databucketActions(
+      'create',
+      databucket,
+      request,
+      response,
+      routeCrudKey,
+      () => {
+        throw new Error('parsing error');
+      },
+      '[{"id": "{{templating}}"}]'
+    );
+
+    strictEqual(databucket.value[1].id, 6);
+  });
+
+  it('should find an item by its CRUD key', () => {
+    databucket.value = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Peter' }
+    ];
+    request.params = { id: '2' };
+    routeCrudKey = 'id';
+
+    const responseBody = databucketActions(
+      'getbyId',
+      databucket,
+      request,
+      response,
+      routeCrudKey
+    );
+
+    deepStrictEqual(responseBody, { id: 2, name: 'Peter' });
+  });
+
   it('should set entire request body if databucket.value != []', () => {
     request.body = { name: 'John' };
     databucket.value = null;


### PR DESCRIPTION
Closes #1547

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRUD routes support custom ID generation for newly created items.
  * IDs can be generated from template expressions, including nested data paths.
  * Numeric generated IDs remain numbers, with sequential or UUID fallback when needed.
  * Existing item lookups continue to use the requested ID directly.
  * Added guidance explaining custom CRUD ID configuration and templating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->