### PR TITLE
Remove cookie secure flag when proxying on HTTP

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -1666,7 +1666,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
 
             const hostname =
               this.options.publicBaseUrl ||
-              `${this.environment.tlsOptions.enabled ? 'https' : 'http'}://${isIPv6(serverAddress.address) ? `[${serverAddress.address}]` : serverAddress.address}:${serverAddress.port}`;
+              `${this.isTls() ? 'https' : 'http'}://${isIPv6(serverAddress.address) ? `[${serverAddress.address}]` : serverAddress.address}:${serverAddress.port}`;
             url = `${hostname}${this.environment.endpointPrefix ? '/' + this.environment.endpointPrefix : ''}${url}`;
           }
 
@@ -2095,6 +2095,12 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
           }
         },
         proxyRes: (proxyRes, request, response) => {
+          if (!this.isTls() && proxyRes.headers['set-cookie']) {
+            proxyRes.headers['set-cookie'] = proxyRes.headers['set-cookie'].map(
+              (cookie) => cookie.replace(/;\s*secure(?=;|$)/gi, '')
+            );
+          }
+
           const buffers: Buffer[] = [];
           proxyRes.on('data', (chunk) => {
             buffers.push(chunk);
@@ -2397,6 +2403,20 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
     }
 
     return tlsOptions;
+  }
+
+  /**
+   * Check if the server is running over TLS (HTTPS).
+   * Falls back to environment configuration when serverInstance is not yet created.
+   */
+  private isTls(): boolean {
+    if (this.serverInstance) {
+      return this.serverInstance instanceof httpsServer;
+    }
+
+    return Boolean(
+      this.environment.tlsOptions?.enabled && !this.options.disableTls
+    );
   }
 
   /**

--- a/packages/commons-server/test/data/environments/test-env.json
+++ b/packages/commons-server/test/data/environments/test-env.json
@@ -19,7 +19,12 @@
           "rulesOperator": "OR",
           "statusCode": 200,
           "label": "Route",
-          "headers": [],
+          "headers": [
+            {
+              "key": "Set-Cookie",
+              "value": "session=abc; Secure; HttpOnly"
+            }
+          ],
           "latency": 0,
           "filePath": "",
           "sendFileAsBody": false,

--- a/packages/commons-server/test/specs/server/server-proxy.test.ts
+++ b/packages/commons-server/test/specs/server/server-proxy.test.ts
@@ -42,6 +42,31 @@ describe('Server should handle proxy configuration', () => {
     deepEqual(body, {});
   });
 
+  it('should remove the secure flag from proxied cookies', async () => {
+    const response = await fetch('http://localhost:3001/test');
+    const cookies = response.headers.getSetCookie();
+
+    equal(cookies.length, 1);
+    equal(/(?:^|;\s*)secure(?=;|$)/i.test(cookies[0]), false);
+    equal(cookies[0].includes('session=abc'), true);
+  });
+
+  it('should continue removing the secure flag from proxied cookies after environment update when server remains HTTP', async () => {
+    proxyServer.updateEnvironment({
+      ...proxyEnv,
+      tlsOptions: { ...proxyEnv.tlsOptions, enabled: true }
+    });
+
+    const response = await fetch('http://localhost:3001/test');
+    const cookies = response.headers.getSetCookie();
+
+    equal(cookies.length, 1);
+    equal(/(?:^|;\s*)secure(?=;|$)/i.test(cookies[0]), false);
+    equal(cookies[0].includes('session=abc'), true);
+
+    proxyServer.updateEnvironment(proxyEnv);
+  });
+
   it('should return response when request matches', async () => {
     const response = await fetch('http://localhost:3001/test2?rule=match');
     equal(response.status, 200);


### PR DESCRIPTION
Closes #611

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #611
**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cookies returned through the proxy no longer include the `Secure` attribute when TLS is disabled, improving compatibility with non-secure local environments.
  * Proxy behavior now correctly reflects the active server connection when determining TLS status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->