### PR TITLE
Allow content-type charset override

### DIFF
--- a/packages/commons-server/src/libs/server/server.ts
+++ b/packages/commons-server/src/libs/server/server.ts
@@ -6,7 +6,6 @@ import {
   Environment,
   FileExtensionsWithTemplating,
   GetContentType,
-  GetRouteResponseContentType,
   Header,
   IsValidURL,
   MimeTypesWithTemplating,
@@ -1478,10 +1477,6 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
 
     // add route latency if any
     setTimeout(() => {
-      const contentType = GetRouteResponseContentType(
-        this.environment,
-        triggeredRouteResponse
-      );
       const routeContentType = GetContentType(triggeredRouteResponse.headers);
 
       // set http code
@@ -1508,10 +1503,6 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         // serve inline body or databucket
       } else {
         let templateParse = true;
-
-        if (contentType.includes('application/json')) {
-          response.set('Content-Type', 'application/json');
-        }
 
         // serve inline body as default
         let content: any = triggeredRouteResponse.body;
@@ -1834,7 +1825,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
       // execute callbacks after generating the template, to be able to use the eventual templating variables in the callback
       this.executeCallbacks(routeResponse, request, response);
 
-      response.send(content);
+      this.sendResponse(response, content);
     } catch (error: any) {
       this.emit('error', ServerErrorCodes.ROUTE_SERVING_ERROR, error, {
         routePath: route.endpoint,
@@ -1846,6 +1837,75 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
         format(ServerMessages.ROUTE_SERVING_ERROR, error.message)
       );
     }
+  }
+
+  /**
+   * Send the response body. If the Content-Type header explicitly specifies a charset,
+   * convert the content to a Buffer with the corresponding character encoding so Express
+   * does not overwrite the user-specified charset with utf-8.
+   *
+   * @param response
+   * @param content
+   */
+  private sendResponse(response: Response, content: string) {
+    const contentTypeHeader = (response.getHeader('Content-Type') ||
+      response.getHeader('content-type')) as string | undefined;
+
+    if (contentTypeHeader && /;\s*charset\s*=/i.test(contentTypeHeader)) {
+      const encoding = this.getBufferEncoding(contentTypeHeader);
+      response.send(Buffer.from(content, encoding));
+    } else {
+      response.send(content);
+    }
+  }
+
+  /**
+   * Determine the buffer encoding from the Content-Type header charset, defaulting to utf-8
+   *
+   * @param contentType
+   */
+  private getBufferEncoding(contentType: string): BufferEncoding {
+    const match = contentType.match(/;\s*charset\s*=\s*"?([^;"]+)"?/i);
+
+    if (match?.[1]) {
+      const charset = match[1].trim().toLowerCase();
+
+      if (
+        [
+          'iso-8859-1',
+          'latin1',
+          'binary',
+          'windows-1252',
+          'iso88591',
+          'iso_8859_1',
+          'iso_8859-1'
+        ].includes(charset)
+      ) {
+        return 'latin1';
+      }
+
+      if (['utf-8', 'utf8'].includes(charset)) {
+        return 'utf-8';
+      }
+
+      if (['ascii', 'us-ascii'].includes(charset)) {
+        return 'ascii';
+      }
+
+      if (
+        ['utf-16le', 'utf16le', 'ucs-2', 'ucs2', 'utf-16', 'utf16'].includes(
+          charset
+        )
+      ) {
+        return 'utf16le';
+      }
+
+      if (Buffer.isEncoding(charset)) {
+        return charset as BufferEncoding;
+      }
+    }
+
+    return 'utf-8';
   }
 
   /**
@@ -1939,7 +1999,7 @@ export class MockoonServer extends (EventEmitter as new () => TypedEmitter<Serve
             // execute callbacks after generating the file content, to be able to use the eventual templating variables in the callback
             this.executeCallbacks(routeResponse, request, response);
 
-            response.send(fileContent);
+            this.sendResponse(response, fileContent);
           } catch (error: any) {
             fileServingError(error);
           }

--- a/packages/commons-server/test/specs/server/response-content-type.test.ts
+++ b/packages/commons-server/test/specs/server/response-content-type.test.ts
@@ -1,0 +1,360 @@
+import { BodyTypes, Environment, RouteType } from '@mockoon/commons';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { resolve as pathResolve } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { MockoonServer } from '../../../src';
+
+describe('Response Content-Type headers', () => {
+  let server: MockoonServer;
+
+  before(async () => {
+    const environment: Environment = {
+      uuid: 'env-content-type-uuid',
+      lastMigration: 32,
+      name: 'Content-Type Test',
+      endpointPrefix: '',
+      latency: 0,
+      port: 3013,
+      hostname: '',
+      routes: [
+        {
+          uuid: 'route-1',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'json-no-charset',
+          responses: [
+            {
+              uuid: 'resp-1',
+              body: '{"message":"hello"}',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'application/json'
+                }
+              ],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        },
+        {
+          uuid: 'route-2',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'json-utf8-charset',
+          responses: [
+            {
+              uuid: 'resp-2',
+              body: '{"message":"hello"}',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'application/json; charset=utf-8'
+                }
+              ],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        },
+        {
+          uuid: 'route-3',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'json-iso-charset',
+          responses: [
+            {
+              uuid: 'resp-3',
+              body: '{"greeting":"café"}',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'application/json; charset=iso-8859-1'
+                }
+              ],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        },
+        {
+          uuid: 'route-4',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'text-plain',
+          responses: [
+            {
+              uuid: 'resp-4',
+              body: 'plain text response',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'text/plain'
+                }
+              ],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        },
+        {
+          uuid: 'route-5',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'custom-content-type',
+          responses: [
+            {
+              uuid: 'resp-5',
+              body: '<xml>test</xml>',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [
+                {
+                  key: 'Content-Type',
+                  value: 'application/xml'
+                }
+              ],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        },
+        {
+          uuid: 'route-6',
+          type: RouteType.HTTP,
+          documentation: '',
+          method: 'get',
+          endpoint: 'inherit-env-header',
+          responses: [
+            {
+              uuid: 'resp-6',
+              body: '{"env":"inherited"}',
+              latency: 0,
+              statusCode: 200,
+              label: '',
+              headers: [],
+              bodyType: BodyTypes.INLINE,
+              filePath: '',
+              databucketID: '',
+              sendFileAsBody: false,
+              rules: [],
+              rulesOperator: 'OR',
+              disableTemplating: false,
+              fallbackTo404: false,
+              default: true,
+              crudKey: 'id',
+              callbacks: []
+            }
+          ],
+          responseMode: null,
+          streamingMode: null,
+          streamingInterval: 0
+        }
+      ],
+      proxyMode: false,
+      proxyHost: '',
+      proxyRemovePrefix: false,
+      tlsOptions: {
+        enabled: false,
+        type: 'CERT',
+        pfxPath: '',
+        certPath: '',
+        keyPath: '',
+        caPath: '',
+        passphrase: ''
+      },
+      cors: true,
+      headers: [
+        {
+          key: 'Content-Type',
+          value: 'application/vnd.api+json'
+        }
+      ],
+      proxyReqHeaders: [],
+      proxyResHeaders: [],
+      data: [],
+      callbacks: [],
+      folders: [],
+      rootChildren: [
+        { type: 'route', uuid: 'route-1' },
+        { type: 'route', uuid: 'route-2' },
+        { type: 'route', uuid: 'route-3' },
+        { type: 'route', uuid: 'route-4' },
+        { type: 'route', uuid: 'route-5' },
+        { type: 'route', uuid: 'route-6' }
+      ]
+    };
+
+    server = new MockoonServer(environment, {
+      environmentDirectory: pathResolve('./test/data/environments/')
+    });
+
+    await new Promise((resolve, reject) => {
+      server.on('started', () => {
+        resolve(true);
+      });
+
+      server.on('error', (error) => {
+        reject(error);
+      });
+
+      server.start();
+    });
+  });
+
+  after(() => {
+    server.stop();
+  });
+
+  it('should let Express add charset=utf-8 when Content-Type is application/json without charset', async () => {
+    const response = await fetch('http://localhost:3013/json-no-charset');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'application/json; charset=utf-8'
+    );
+    const body = await response.json();
+    deepStrictEqual(body, { message: 'hello' });
+  });
+
+  it('should preserve explicit charset=utf-8 when defined', async () => {
+    const response = await fetch('http://localhost:3013/json-utf8-charset');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'application/json; charset=utf-8'
+    );
+    const body = await response.json();
+    deepStrictEqual(body, { message: 'hello' });
+  });
+
+  it('should preserve explicit charset=iso-8859-1 and encode body accordingly', async () => {
+    const response = await fetch('http://localhost:3013/json-iso-charset');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'application/json; charset=iso-8859-1'
+    );
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const text = buffer.toString('latin1');
+    deepStrictEqual(JSON.parse(text), { greeting: 'café' });
+    // In ISO-8859-1 (Latin-1), 'é' is 1 byte (0xE9), not UTF-8 2 bytes (0xC3 0xA9)
+    strictEqual(buffer.includes(0xe9), true);
+  });
+
+  it('should let Express add charset=utf-8 when Content-Type is text/plain without charset', async () => {
+    const response = await fetch('http://localhost:3013/text-plain');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'text/plain; charset=utf-8'
+    );
+    const body = await response.text();
+    strictEqual(body, 'plain text response');
+  });
+
+  it('should let Express add charset=utf-8 when Content-Type is application/xml without charset', async () => {
+    const response = await fetch('http://localhost:3013/custom-content-type');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'application/xml; charset=utf-8'
+    );
+    const body = await response.text();
+    strictEqual(body, '<xml>test</xml>');
+  });
+
+  it('should let Express apply default header processing on inherited environment Content-Type', async () => {
+    const response = await fetch('http://localhost:3013/inherit-env-header');
+
+    strictEqual(response.status, 200);
+    strictEqual(
+      response.headers.get('content-type'),
+      'application/vnd.api+json; charset=utf-8'
+    );
+  });
+});


### PR DESCRIPTION
Honor user provided charsets.

Closes #539

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response handling to preserve explicitly configured `Content-Type` headers and character sets.
  - Ensured response bodies are encoded correctly for character sets including UTF-8 and ISO-8859-1.
  - Preserved content-type headers inherited from environment-level settings.
  - Improved consistency when returning JSON, plain text, XML, and custom media types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->