### PR TITLE
Warn users when a URL will be dereferenced during OpenAPI import

### DIFF
--- a/packages/app/src/renderer/app/components/modals/openapi-import-modal/openapi-import-modal.component.html
+++ b/packages/app/src/renderer/app/components/modals/openapi-import-modal/openapi-import-modal.component.html
@@ -2,6 +2,7 @@
 @let bodyEditorMode = bodyEditorMode$ | async;
 @let reimportPreview = reimportPreview$ | async;
 @let previewPlan = getPreviewPlan(reimportPreview);
+@let externalRefs = externalRefs$ | async;
 
 <div class="modal-header">
   <h4 class="modal-title">
@@ -82,6 +83,27 @@
           [mode]="bodyEditorMode"
         />
       </div>
+      @if (externalRefs && externalRefs.length > 0) {
+        <div class="mt-2 mb-0 d-flex flex-column gap-1 p-2">
+          <div class="d-flex align-items-center">
+            <app-svg icon="warning" class="text-warning me-2 flex-shrink-0" />
+            <span class="fw-bold"> External references detected: </span>
+          </div>
+          <div class="small">
+            The following external URLs will be fetched during import:
+          </div>
+          <ul
+            class="mb-0 ps-3 small text-break overflow-auto"
+            style="max-height: 80px"
+          >
+            @for (ref of externalRefs; track ref) {
+              <li>
+                <code>{{ ref }}</code>
+              </li>
+            }
+          </ul>
+        </div>
+      }
       <p class="px-2 pt-2 mb-0 text-muted fst-italic">
         Note: URL references (<code>$ref</code>) will be automatically resolved.
         File references are not supported.

--- a/packages/app/src/renderer/app/components/modals/openapi-import-modal/openapi-import-modal.component.ts
+++ b/packages/app/src/renderer/app/components/modals/openapi-import-modal/openapi-import-modal.component.ts
@@ -150,6 +150,21 @@ export class OpenapiImportModalComponent {
       }
     })
   );
+  public externalRefs$: Observable<string[]> = this.importForm
+    .get('content')
+    .valueChanges.pipe(
+      startWith(this.importForm.get('content').value),
+      debounceTime(250),
+      map((content) => {
+        if (!content?.trim()) {
+          return [];
+        }
+
+        const converter = new OpenApiConverter();
+
+        return converter.extractExternalRefs(content);
+      })
+    );
   public isWeb = Config.isWeb;
   public choiceForm = form(signal<Record<string, boolean>>({}));
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -168,6 +168,7 @@ The mocks will run by default on the ports and hostnames specified in the files.
 |-k, --token | Access token used to fetch cloud-hosted Mockoon environments (see  [access token documentation](https://mockoon.com/cloud/docs/access-tokens/))|
 |--max-callback-depth | Maximum call stack depth for route responses with callbacks (default: 100)|
 |--enable-route-metadata-headers | Add [route metadata headers](https://mockoon.com/docs/latest/response-configuration/response-headers/#mockoon-response-headers) to responses (UUID and response metadata) (default: false)|
+|--disable-external-refs | Disable fetching of external HTTP/HTTPS `$ref` references when loading OpenAPI specifications (default: false)|
 |-h, --help | Show CLI help|
 
 **Examples**:
@@ -281,6 +282,7 @@ Note: This command is similar to the app's import feature, but it will not impor
 |-i, --input [required] |Path or URL to your Swagger v2/OpenAPI v3 file|
 |-o, --output [required] |Generated Mockoon path and name (e.g. `./environment.json`)|
 |-p, --prettify |Prettify output|
+|--disable-external-refs |Disable fetching of external HTTP/HTTPS `$ref` references when importing OpenAPI specifications (default: false)|
 |-h, --help |Show CLI help|
 
 **Examples**:

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -27,6 +27,11 @@ export default class Import extends Command {
       char: 'p',
       description: 'Prettify output',
       default: false
+    }),
+    'disable-external-refs': Flags.boolean({
+      description:
+        'Disable fetching of external HTTP/HTTPS $ref references when importing OpenAPI specifications',
+      default: false
     })
   };
 
@@ -34,7 +39,9 @@ export default class Import extends Command {
     const { flags: userFlags } = await this.parse(Import);
 
     try {
-      const parsedEnvironment = await parseDataFile(userFlags.input);
+      const parsedEnvironment = await parseDataFile(userFlags.input, {
+        disableExternalRefs: userFlags['disable-external-refs']
+      });
 
       const data: string = JSON.stringify(
         parsedEnvironment.environment,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -158,6 +158,11 @@ export default class Start extends Command {
     'max-callback-depth': Flags.integer({
       description: `Maximum call stack depth for route responses with callback functions (default: ${defaultMaxCallbackDepth})`,
       default: defaultMaxCallbackDepth
+    }),
+    'disable-external-refs': Flags.boolean({
+      description:
+        'Disable fetching of external HTTP/HTTPS $ref references when loading OpenAPI specifications',
+      default: false
     })
   };
 
@@ -199,7 +204,8 @@ export default class Start extends Command {
           {
             port: userFlags.port[index],
             hostname: userFlags.hostname[index],
-            proxy: userFlags.proxy as 'enabled' | 'disabled'
+            proxy: userFlags.proxy as 'enabled' | 'disabled',
+            disableExternalRefs: userFlags['disable-external-refs']
           },
           userFlags.repair,
           userFlags.token
@@ -255,7 +261,8 @@ export default class Start extends Command {
                 {
                   port: userFlags.port[index],
                   hostname: userFlags.hostname[index],
-                  proxy: userFlags.proxy as 'enabled' | 'disabled'
+                  proxy: userFlags.proxy as 'enabled' | 'disabled',
+                  disableExternalRefs: userFlags['disable-external-refs']
                 },
                 userFlags.repair,
                 userFlags.token

--- a/packages/cli/src/libs/data.ts
+++ b/packages/cli/src/libs/data.ts
@@ -132,6 +132,7 @@ export const parseDataFile = async (
     port?: number;
     hostname?: string;
     proxy?: 'enabled' | 'disabled';
+    disableExternalRefs?: boolean;
   } = { port: undefined, hostname: undefined },
   repair = false,
   token?: string
@@ -142,7 +143,9 @@ export const parseDataFile = async (
   let environment: Environment | null = null;
 
   try {
-    environment = await openAPIConverter.convertFromOpenAPI(data);
+    environment = await openAPIConverter.convertFromOpenAPI(data, undefined, {
+      disableExternalRefs: userOptions.disableExternalRefs
+    });
   } catch (openAPIError) {
     if (openAPIError instanceof Error) {
       errorMessage += `\nOpenAPI parser: ${openAPIError.message}`;

--- a/packages/cli/test/specs/import-command.test.ts
+++ b/packages/cli/test/specs/import-command.test.ts
@@ -198,4 +198,29 @@ describe('Import command', () => {
 
     await rm('./tmp/import-url-file-prettified.json');
   });
+  it('should import with --disable-external-refs flag', async () => {
+    await spawnCli([
+      'import',
+      '--input',
+      './test/data/openapi/petstore.yaml',
+      '--output',
+      './tmp/import-yaml-file-no-ext-refs.json',
+      '--disable-external-refs'
+    ]);
+
+    const importedFile = await readFile(
+      './tmp/import-yaml-file-no-ext-refs.json'
+    );
+    const importedContent = importedFile.toString();
+    const importedJson = clearAllUuids(JSON.parse(importedContent));
+    const expectedFile = await readFile(
+      './test/data/envs/petstore-imported.json'
+    );
+    const expectedContent = clearAllUuids(JSON.parse(expectedFile.toString()));
+
+    ok(!importedContent.includes('\n'));
+    deepStrictEqual(importedJson, expectedContent);
+
+    await rm('./tmp/import-yaml-file-no-ext-refs.json');
+  });
 });

--- a/packages/cli/test/specs/run-from-openapi.test.ts
+++ b/packages/cli/test/specs/run-from-openapi.test.ts
@@ -38,4 +38,23 @@ describe('Run from OpenAPI spec', () => {
 
     ok(stdout.includes('Server started'));
   });
+
+  it('should support --disable-external-refs flag', async () => {
+    const { instance, output } = await spawnCli([
+      'start',
+      '--data',
+      './test/data/openapi/petstore.yaml',
+      '--disable-external-refs'
+    ]);
+
+    const result = await (await fetch('http://localhost:3000/v1/pets')).json();
+
+    notStrictEqual(result[0].id, undefined);
+
+    instance.kill();
+
+    const { stdout } = await output;
+
+    ok(stdout.includes('Server started'));
+  });
 });

--- a/packages/commons/src/libs/openapi-converter.ts
+++ b/packages/commons/src/libs/openapi-converter.ts
@@ -41,14 +41,17 @@ export class OpenApiConverter {
    * File loading is not done here to keep this library compatible with browser usage.
    *
    * @param spec - raw specification string
+   * @param port - optional port override
+   * @param options - optional converter options (e.g. disableExternalRefs)
    * @throws {Error}
    */
   public async convertFromOpenAPI(
     spec: string,
-    port?: number
+    port?: number,
+    options: { disableExternalRefs?: boolean } = {}
   ): Promise<Environment | null> {
     const parsedSpec = this.parseJsonOrYaml(spec);
-    const schema = await this.dereference(parsedSpec);
+    const schema = await this.dereference(parsedSpec, options);
 
     if (this.isSwagger(schema)) {
       return this.convertFromSwagger(schema, port);
@@ -211,14 +214,81 @@ export class OpenApiConverter {
   }
 
   /**
+   * Extract all external (HTTP/HTTPS) $ref URLs from an OpenAPI specification
+   *
+   * @param spec - raw specification string or parsed specification object
+   * @returns Array of unique external $ref URLs
+   */
+  public extractExternalRefs(spec: string | any): string[] {
+    let parsedSpec: any;
+
+    if (typeof spec === 'string') {
+      try {
+        parsedSpec = this.parseJsonOrYaml(spec);
+      } catch {
+        return [];
+      }
+    } else {
+      parsedSpec = spec;
+    }
+
+    if (!parsedSpec || typeof parsedSpec !== 'object') {
+      return [];
+    }
+
+    const externalRefs = new Set<string>();
+    const visited = new Set<any>();
+
+    const crawl = (current: any) => {
+      if (
+        current === null ||
+        typeof current !== 'object' ||
+        visited.has(current)
+      ) {
+        return;
+      }
+
+      visited.add(current);
+
+      if (Array.isArray(current)) {
+        for (const item of current) {
+          crawl(item);
+        }
+
+        return;
+      }
+
+      if (typeof current.$ref === 'string') {
+        const ref = current.$ref.trim();
+
+        if (ref.startsWith('http://') || ref.startsWith('https://')) {
+          externalRefs.add(ref);
+        }
+      }
+
+      for (const key of Object.keys(current)) {
+        crawl(current[key]);
+      }
+    };
+
+    crawl(parsedSpec);
+
+    return Array.from(externalRefs);
+  }
+
+  /**
    * Dereference all $ref in an OpenAPI specification
    * Handles both internal (#/components/schemas/...) and external (URL) references
    * Includes circular dependency detection and caching
    *
    * @param parsedSpec - The parsed OpenAPI specification
+   * @param options - Options for dereferencing (e.g. disableExternalRefs)
    * @returns Promise<any> - The dereferenced schema
    */
-  public async dereference(parsedSpec: any): Promise<any> {
+  public async dereference(
+    parsedSpec: any,
+    options: { disableExternalRefs?: boolean } = {}
+  ): Promise<any> {
     const externalCache = new Map<string, any>();
     const internalCache = new Map<string, any>();
     const dereferenceCache = new Map<string, any>();
@@ -277,6 +347,10 @@ export class OpenApiConverter {
 
     const processRef = async (refPath: string) => {
       if (refPath.startsWith('http://') || refPath.startsWith('https://')) {
+        if (options.disableExternalRefs) {
+          return null;
+        }
+
         // External URL reference
         const [url, fragment] = refPath.split('#');
         const externalSchema = await fetchExternalRef(url);

--- a/packages/commons/test/specs/openapi-converter.test.ts
+++ b/packages/commons/test/specs/openapi-converter.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from 'node:assert';
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { before, describe, it } from 'node:test';
 import { OpenApiConverter } from '../../src';
@@ -296,5 +296,101 @@ describe('OpenAPI converter', () => {
 }`;
 
     strictEqual(route?.responses[0].body, expectedBody);
+  });
+
+  it('should extract all unique external $ref URLs', () => {
+    const openApiConverter = new OpenApiConverter();
+    const specWithRefs = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: 'https://example.com/schemas/user.json'
+                    }
+                  }
+                }
+              },
+              '400': {
+                description: 'Error',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: 'https://example.com/schemas/user.json'
+                    }
+                  }
+                }
+              },
+              '500': {
+                description: 'Server Error',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: 'http://internal.service/error.json#/definitions/error'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          Local: {
+            $ref: '#/components/schemas/Other'
+          }
+        }
+      }
+    });
+
+    const refs = openApiConverter.extractExternalRefs(specWithRefs);
+
+    deepStrictEqual(refs, [
+      'https://example.com/schemas/user.json',
+      'http://internal.service/error.json#/definitions/error'
+    ]);
+  });
+
+  it('should not fetch external refs when disableExternalRefs is true', async () => {
+    const openApiConverter = new OpenApiConverter();
+    const specWithExternalRef = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Test External Ref Disabled', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: 'http://127.0.0.1:99999/nonexistent.json'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Without disableExternalRefs, this would fail attempting to fetch non-existent endpoint
+    const environment = await openApiConverter.convertFromOpenAPI(
+      specWithExternalRef,
+      undefined,
+      { disableExternalRefs: true }
+    );
+
+    strictEqual(environment?.name, 'Test External Ref Disabled');
+    strictEqual(environment?.routes.length, 1);
   });
 });


### PR DESCRIPTION
Also add a new CLI flag to disable dereferencing of URLs.

Closes #2339

<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->

<!-- Link to the original issue -->

Closes #{issue_number}

**Technical implementation details**

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenAPI imports now identify external references and display the URLs that will be fetched.
  - Added a `--disable-external-refs` option to import and start commands, allowing external HTTP/HTTPS references to remain unresolved.
- **Documentation**
  - CLI documentation now describes the new option and its default behavior.
- **Tests**
  - Added coverage for external reference detection, disabled fetching, and CLI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->