### PR TITLE
When using a custom protocol to open an environment, prompt before fetch

### DIFF
--- a/packages/app/src/renderer/app/services/environments.service.ts
+++ b/packages/app/src/renderer/app/services/environments.service.ts
@@ -501,6 +501,7 @@ export class EnvironmentsService {
     options?: {
       environment?: Environment;
       insertAfterIndex?: number;
+      filePath?: string;
       promptSave?: boolean;
       cloud?: boolean;
       setActive?: boolean;
@@ -511,6 +512,7 @@ export class EnvironmentsService {
       ...{
         environment: null,
         insertAfterIndex: null,
+        filePath: null,
         promptSave: true,
         cloud: false,
         setActive: false
@@ -520,7 +522,9 @@ export class EnvironmentsService {
 
     let filePath$: Observable<string>;
 
-    if (options.promptSave) {
+    if (options.filePath) {
+      filePath$ = of(options.filePath);
+    } else if (options.promptSave) {
       filePath$ = this.dialogsService.showSaveDialog(
         'Save your new environment'
       );
@@ -647,27 +651,44 @@ export class EnvironmentsService {
    */
   public newEnvironmentFromURL(url: string) {
     if (url) {
-      this.loggerService.logMessage('info', 'NEW_ENVIRONMENT_FROM_URL', {
-        url
-      });
+      return this.dialogsService
+        .showSaveDialog('Save your new environment')
+        .pipe(
+          filter((filePath) => !!filePath),
+          switchMap((filePath) => {
+            this.loggerService.logMessage('info', 'NEW_ENVIRONMENT_FROM_URL', {
+              url
+            });
 
-      return this.http.get(url, { responseType: 'text' }).pipe(
-        map<string, Environment>((data) => JSON.parse(data)),
-        switchMap((environment: Environment) => this.verifyData(environment)),
-        switchMap((environment: Environment) => {
-          const migratedEnvironment =
-            this.dataService.migrateAndValidateEnvironment(environment);
+            return this.http.get(url, { responseType: 'text' }).pipe(
+              map<string, Environment>((data) => JSON.parse(data)),
+              switchMap((environment: Environment) =>
+                this.verifyData(environment)
+              ),
+              switchMap((environment: Environment) => {
+                const migratedEnvironment =
+                  this.dataService.migrateAndValidateEnvironment(environment);
 
-          return this.addEnvironment({ environment: migratedEnvironment });
-        }),
-        catchError((error) => {
-          this.loggerService.logMessage('error', 'NEW_ENVIRONMENT_URL_ERROR', {
-            error
-          });
+                return this.addEnvironment({
+                  environment: migratedEnvironment,
+                  filePath,
+                  promptSave: false
+                });
+              })
+            );
+          }),
+          catchError((error) => {
+            this.loggerService.logMessage(
+              'error',
+              'NEW_ENVIRONMENT_URL_ERROR',
+              {
+                error
+              }
+            );
 
-          return EMPTY;
-        })
-      );
+            return EMPTY;
+          })
+        );
     }
 
     return EMPTY;


### PR DESCRIPTION
<!--
IMPORTANT RULES:
- Read the contributing guidelines first!
- All pull requests must stem from an issue. No issue, no PR review, no merge.
- Implementation, UI, UX, needs to be discussed either in the issue, or in the PR before starting the development.
- The issue must be assigned to you before starting the development. Comment on the issue if you want to work on it, and wait for it to be assigned to you by a maintainer.
- Commits should be squashed to a single commit, or more if relevant. They should follow this guide https://chris.beams.io/posts/git-commit/ and contain the following mention: `Closes #{issue_number}`.
- Follow the branch naming convention: feature|fix|chore/{issue_number}-description.
- Follow the template!
 -->


**Technical implementation details**

When loading an environment from a custom protocol URL (i.e. `mockoon://`) prompt for save before actually fetching the file. This will make more obvious that an external call will be triggered.

<!-- Describe your implementation in details if it's relevant -->

**Checklist**

<!-- Check relevant boxes -->

- [ ] data migration added (@mockoon/commons)
- [ ] commons lib tests added (@mockoon/commons)
- [ ] commons-server lib tests added (@mockoon/commons-server)
- [ ] CLI tests added (@mockoon/cli)
- [ ] desktop UI automated tests added (@mockoon/app)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can choose the destination file before downloading an environment from a URL.
  - Environment imports now support saving directly to a selected file path.

- **Bug Fixes**
  - Improved handling of canceled file-selection dialogs during environment imports.
  - Improved error handling for download, parsing, validation, and migration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->